### PR TITLE
util.TimeSpan::equals()

### DIFF
--- a/ports/classes/net/xp_framework/unittest/util/TimeSpanTest.class.php
+++ b/ports/classes/net/xp_framework/unittest/util/TimeSpanTest.class.php
@@ -283,5 +283,23 @@
     public function formatPercent() {
       $this->assertEquals('%1d%1h%', create(new TimeSpan(91865))->format('%%%ed%%%yh%%'));
     }
+
+    /**
+     * Test timespan compare
+     *
+     */
+    #[@test]
+    public function compareTwoEqualInstances() {
+      $this->assertEquals(new TimeSpan(3600), new TimeSpan(3600));
+    }
+
+    /**
+     * Test timespan compare
+     *
+     */
+    #[@test]
+    public function compareTwoUnequalInstances() {
+      $this->assertNotEquals(new TimeSpan(3600), new TimeSpan(0));
+    }
   }
 ?>

--- a/ports/unittest/date.ini
+++ b/ports/unittest/date.ini
@@ -12,6 +12,9 @@ class="net.xp_framework.unittest.util.DateTest"
 [timezone]
 class="net.xp_framework.unittest.util.TimeZoneTest"
 
+[timespan]
+class="net.xp_framework.unittest.util.TimeSpanTest"
+
 [dateutil]
 class="net.xp_framework.unittest.util.DateUtilTest"
 

--- a/skeleton/util/TimeSpan.class.php
+++ b/skeleton/util/TimeSpan.class.php
@@ -329,8 +329,18 @@
       return $return;
     }
 
+    /*
+     * Indicates whether the timespan to compare equals this timespan
+     *
+     * @param   util.TimeSpan cmp
+     * @return  bool TRUE if timespans are equal
+     */
+    public function equals($cmp) {
+      return ($cmp instanceof self) && ($cmp->getSeconds() == $this->getSeconds());
+    }
+
     /**
-     * creates a string representation
+     * Creates a string representation
      *
      * @see     xp://util.TimeSpan#format
      * @param   string format, defaults to '%ed, %yh, %jm, %ws'


### PR DESCRIPTION
Hi,

while writing some unittests, I came across a case that will finally assert something like this:

assertEquals(new TimeSpan(3600), new TimeSpan(3600))

and this call marks the test as invalid. I tracked down the issue to the fact that the "util.TimeSpan" class does not override the "lang.Object::equals()"  -- which compares the "__id" member. The 
"lang.Object::equals()" is however overridden by other classes such as "util.Date" or "util.Hashmap".

Attached you can find a patch that addresses this issue, and two unittest methods to test the change.

Also, I saw that the "net.xp_framework.unittest.util.TimeSpanTest" test was not included in any of the "ports/unittest/*.ini" files, so I added it to "date.ini"

-- marius
