### PR TITLE
ConnectionManager::register() returns passed connection, not registered

### DIFF
--- a/core/src/main/php/rdbms/ConnectionManager.class.php
+++ b/core/src/main/php/rdbms/ConnectionManager.class.php
@@ -91,17 +91,14 @@
       $host= (NULL == $hostAlias) ? $conn->dsn->getHost() : $hostAlias;
       $user= (NULL == $userAlias) ? $conn->dsn->getUser() : $userAlias;
       
-      if (!isset($this->pool[$user.'@'.$host])) {
-        $this->pool[$user.'@'.$host]= $conn;
-      }
-      
+      $this->pool[$user.'@'.$host]= $conn;
       return $conn;
     }
     
     /**
      * Queue a connection string for registering on demand.
      *
-     * @param   rdbms.DSN dsn The connection's DSN
+     * @param   string dsn The connection's DSN
      * @return  rdbms.DSN
      * @param   string hostAlias default NULL
      * @param   string userAlias default NULL
@@ -111,10 +108,7 @@
       $host= (NULL == $hostAlias) ? $dsn->getHost() : $hostAlias;
       $user= (NULL == $userAlias) ? $dsn->getUser() : $userAlias;
       
-      if (!isset($this->pool[$user.'@'.$host])) {
-        $this->pool[$user.'@'.$host]= $str;
-      }
-      
+      $this->pool[$user.'@'.$host]= $str;
       return $dsn;
     }
     

--- a/core/src/test/php/net/xp_framework/unittest/rdbms/QueuedConnectionManagerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rdbms/QueuedConnectionManagerTest.class.php
@@ -66,7 +66,7 @@
      *
      */
     #[@test]
-    public function queueDoesNotOverwritePreviouslyRegistered() {
+    public function queueOverwritesPreviouslyRegistered() {
       $conn1= 'mock://user:pass@host/db1';
       $conn2= 'mock://user:pass@host/db2';
       $cm= $this->instanceWith(array());
@@ -74,7 +74,7 @@
       $this->assertEquals(new DSN($conn1), $cm->queue($conn1));
       $this->assertEquals(new DSN($conn2), $cm->queue($conn2));
 
-      $this->assertEquals(new DSN($conn1), $cm->getByHost('host', 0)->dsn);
+      $this->assertEquals(new DSN($conn2), $cm->getByHost('host', 0)->dsn);
     }
   }
 ?>

--- a/core/src/test/php/net/xp_framework/unittest/rdbms/RegisteredConnectionManagerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rdbms/RegisteredConnectionManagerTest.class.php
@@ -76,7 +76,7 @@
      *
      */
     #[@test]
-    public function registerDoesNotOverwritePreviouslyRegistered() {
+    public function registerOverwritesPreviouslyRegistered() {
       $conn1= DriverManager::getConnection('mock://user:pass@host/db1');
       $conn2= DriverManager::getConnection('mock://user:pass@host/db2');
       $cm= $this->instanceWith(array());
@@ -84,7 +84,7 @@
       $this->assertEquals($conn1, $cm->register($conn1));
       $this->assertEquals($conn2, $cm->register($conn2));
 
-      $this->assertEquals($conn1, $cm->getByHost('host', 0));
+      $this->assertEquals($conn2, $cm->getByHost('host', 0));
     }
   }
 ?>


### PR DESCRIPTION
ConnectionManager::register() returns a DBConnection object when being called.

When calling ConnectionManager::register() with a connection that had already
been registered, it will return the DBConnection, that had been passed in; if a
connection was already registered with same {database,user} combination, it
won't be overwritten, but the method does not return the already registered
connection, but the passed one.

The method should either throw an exception about the connection already being
registered, or - more bc friendly - pass the registered connection out.
