### PR TITLE
Fix annotations parsing in XPClass

### DIFF
--- a/core/src/test/php/net/xp_framework/unittest/core/AnnotatedClass.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/AnnotatedClass.class.php
@@ -34,6 +34,13 @@
     public function stringValue() { }
 
     /**
+     * Method annotated with an integer value
+     *
+     */
+    #[@intval(123)]
+    public function integerValue() { }
+
+    /**
      * Method annotated with an annotation with a hash value containing one
      * key/value pair
      *
@@ -96,7 +103,7 @@
     public function stringAssignedWithoutWhitespace() {}
 
     /**
-     * Method annotated with multiple values which contains equal signs
+     * Method annotated with multiple values that contain equal signs
      *
      */
     #[@permission(names= array('rn=login, rt=config1', 'rn=login, rt=config2'))]
@@ -110,10 +117,18 @@
     public function multipleStringValues() { }
 
     /**
-     * Method annotated with multiple values but without using the 'array' keyword
+     * Method annotated with multiple mixed values
      *
      */
-    #[@function(arguments= ('arg1', 'arg2'))]
+    #[@permission('rn=login, rt=config1', 123, 10.34, false)]
+    public function multipleMixedValues() { }
+
+    /**
+     * Method annotated with multiple values but without using
+     * the 'array' keyword
+     *
+     */
+    #[@function(arguments= ['arg1', 'arg2'])]
     public function multipleWithoutArrayKeyword() { }
   }
 ?>

--- a/core/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/AnnotationTest.class.php
@@ -163,6 +163,17 @@
     }
 
     /**
+     * Tests getAnnotation() returns the integer associated with the 
+     * annotation.
+     *
+     * @see     xp://net.xp_framework.unittest.core.AnnotatedClass#integerValue
+     */
+    #[@test]
+    public function integerAnnotationValue() {
+      $this->assertEquals(123, $this->methodAnnotation('integerValue', 'intval'));
+    }
+
+    /**
      * Tests getAnnotation() returns the string associated with the 
      * annotation.
      *
@@ -272,6 +283,7 @@
      * Test annotation with mulitple values containing equal signs
      * is parsed correctly.
      *
+     * @see     xp://net.xp_framework.unittest.core.AnnotatedClass#multipleValuesWithStringsAndEqualSigns
      */
      #[@test]
      public function multipleValuesWithStringsAndEqualSigns() {
@@ -286,6 +298,7 @@
     /**
      * Test annotation with multiple string values is parsed correctly.
      *
+     * @see     xp://net.xp_framework.unittest.core.AnnotatedClass#multipleStringValues
      */
      #[@test]
      public function multipleStringValues() {
@@ -296,9 +309,23 @@
      }
 
     /**
+     * Test annotation with multiple mixed values is parsed correctly.
+     *
+     * @see     xp://net.xp_framework.unittest.core.AnnotatedClass#multipleMixedValues
+     */
+     #[@test]
+     public function multipleMixedValues() {
+       $this->assertEquals(
+         array('rn=login, rt=config1', 123, 10.34, false),
+         $this->methodAnnotation('multipleMixedValues', 'permission')
+       );
+     }
+
+    /**
      * Test annotation with multiple annotations without using
      * the 'array' keyword is parsed correctly.
      *
+     * @see     xp://net.xp_framework.unittest.core.AnnotatedClass#multipleWithoutArrayKeyword
      */
      #[@test]
      public function multipleWithoutArrayKeyword() {


### PR DESCRIPTION
Hi,

The attached commit fixes the following issue:
- Fix annotation parsing for values that contain the equal sign: @anno(key= 'rn=name,rt=type')

And adds the following enhancements:
- Add support for multiple string annotations: @anno('str1', 'str2')
- Add support to ignore the 'array' keyword when defining multiple values: @anno(key= (1, 2))

I ran a quick performance test and the result is that the new 'preg_match' plus the 'eval' (that parse the annotations in XPClass) is somewhere from 40% to 80% slower than the original.

Cheers,
-- Marius
