### PR TITLE
Add default logger to scriptlet.xml.workflow.Handler 

### DIFF
--- a/core/src/main/php/scriptlet/xml/workflow/AbstractState.class.php
+++ b/core/src/main/php/scriptlet/xml/workflow/AbstractState.class.php
@@ -29,6 +29,7 @@
      * @return  scriptlet.xml.workflow.Handler the added handler
      */
     public function addHandler($handler) {
+      $handler->setTrace($this->cat);
       $this->handlers[]= $handler;
       return $handler;
     }

--- a/core/src/main/php/scriptlet/xml/workflow/Handler.class.php
+++ b/core/src/main/php/scriptlet/xml/workflow/Handler.class.php
@@ -4,6 +4,8 @@
  * $Id$ 
  */
 
+  uses('util.log.Traceable');
+
   // Handler stati
   define('HANDLER_SETUP',       'setup');
   define('HANDLER_FAILED',      'failed');
@@ -23,8 +25,9 @@
    * @see      xp://scriptlet.xml.workflow.AbstractState#addHandler
    * @purpose  Base class
    */
-  class Handler extends Object {
+  class Handler extends Object implements Traceable {
     public
+      $cat          = NULL,
       $wrapper      = NULL,
       $values       = array(HVAL_PERSISTENT => array(), HVAL_FORMPARAM => array()),
       $errors       = array(),
@@ -281,5 +284,15 @@
      * @param   scriptlet.xml.Context context
      */
     public function finalize($request, $response, $context) { }
+
+    /**
+     * Set a trace for debugging
+     *
+     * @param   util.log.LogCategory cat
+     * @see     xp://util.log.Traceable
+     */
+    public function setTrace($cat) { 
+      $this->cat= $cat;
+    }
   }
 ?>


### PR DESCRIPTION
Hi, 

As scriptlet.xml.workflow.AbstractState declares its $cat object for logging, we should have something similar in the handler; so, for every handler being added to the state it will be able to use that state's logger object.

Regards,
Oana
