### PR TITLE
Fix exitcode value when uncaught exception occurs

### DIFF
--- a/core/ChangeLog
+++ b/core/ChangeLog
@@ -6,6 +6,17 @@ Version ?.?.?, released ????-??-??
 ----------------------------------
 Git commit: ?????
 
+Heads up!
+~~~~~~~~~
+
+Features
+~~~~~~~~
+
+Bugfixes
+~~~~~~~~
+- Changed program's exit code to 0xff in case an uncaught
+  exception occurs.
+  (kiesel)
 
 
 Version 5.8.2, released 2011-09-07

--- a/tools/tools/class.php
+++ b/tools/tools/class.php
@@ -54,6 +54,7 @@
   //     Exception handler
   function __except($e) {
     fputs(STDERR, 'Uncaught exception: '.xp::stringOf($e));
+    exit(0xFF);
   }    
   // }}}
 

--- a/tools/tools/xar.php
+++ b/tools/tools/xar.php
@@ -54,6 +54,7 @@
   //     Exception handler
   function __except($e) {
     fputs(STDERR, 'Uncaught exception: '.xp::stringOf($e));
+    exit(0xFF);
   }    
   // }}}
 


### PR DESCRIPTION
On uncaught errors, an application's exitcode is 0, which makes that case not detectable in shell scripts / other programs.

This patch sets exitcode 0xFF (= 255) on uncaught exceptions.
