### PR TITLE
Use traits

### DIFF
--- a/core/src/main/php/lang.base.php
+++ b/core/src/main/php/lang.base.php
@@ -4,7 +4,140 @@
  * $Id$
  */
 
+  // {{{ trait __xp
+  //     our root object's functionality, used by Object and Throwable
+  trait __xp {
+    public $__id;
+
+    /**
+     * Static field read handler
+     *
+     */
+    public static function __getStatic($name) {
+      if ("\7" === $name{0}) {
+        $t= debug_backtrace();
+        return eval('return '.$t[1]['args'][0][0].'::$'.substr($name, 1).';');
+      }
+      return NULL;
+    }
+
+    /**
+     * Static field read handler
+     *
+     */
+    public static function __setStatic($name, $value) {
+      if ("\7" === $name{0}) {
+        $t= debug_backtrace();
+        eval($t[1]['args'][0][0].'::$'.substr($name, 1).'= $value;');
+        return;
+      }
+    }
+
+    /**
+     * Static method handler
+     *
+     */
+    public static function __callStatic($name, $args) {
+      if ("\7" === $name{0}) {
+        $t= debug_backtrace();
+        return call_user_func_array(array($t[1]['args'][0][0], substr($name, 1)), $args);
+      }
+      $t= debug_backtrace();
+      throw new Error('Call to undefined method '.$t[1]['class'].'::'.$name);
+    }
+
+    /**
+     * Field read handler
+     *
+     */
+    public function __get($name) {
+      if ("\7" === $name{0}) {
+        return $this->{substr($name, 1)};
+      }
+      return NULL;
+    }
+
+    /**
+     * Field write handler
+     *
+     */
+    public function __set($name, $value) {
+      if ("\7" === $name{0}) {
+        $this->{substr($name, 1)}= $value;
+        return;
+      }
+      $this->{$name}= $value;
+    }
+
+    /**
+     * Method handler
+     *
+     */
+    public function __call($name, $args) {
+      if ("\7" === $name{0}) {
+        return call_user_func_array(array($this, substr($name, 1)), $args);
+      }
+      $t= debug_backtrace();
+      $i= 1; $s= sizeof($t);
+      while ($i++ < $s && !isset($t[$i]['class'])) { }
+      $scope= $t[$i]['class'];
+      if (isset(xp::$registry['ext'][$scope])) {
+        foreach (xp::$registry['ext'][$scope] as $type => $class) {
+          if (!$this instanceof $type || !method_exists($class, $name)) continue;
+          array_unshift($args, $this);
+          return call_user_func_array(array($class, $name), $args);
+        }
+      }
+      throw new Error('Call to undefined method '.$this->getClassName().'::'.$name.'() from scope '.xp::nameOf($scope));
+    }
+
+    /**
+     * Returns a hashcode for this object
+     *
+     * @return  string
+     */
+    public function hashCode() {
+      if (!$this->__id) $this->__id= microtime();
+      return $this->__id;
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     *
+     * @param   lang.Generic cmp
+     * @return  bool TRUE if the compared object is equal to this object
+     */
+    public function equals($cmp) {
+      if (!$cmp instanceof Generic) return FALSE;
+      if (!$this->__id) $this->__id= microtime();
+      if (!$cmp->__id) $cmp->__id= microtime();
+      return $this === $cmp;
+    }
+
+    /**
+     * Returns the fully qualified class name for this class 
+     * (e.g. "io.File")
+     *
+     * @return  string fully qualified class name
+     */
+    public function getClassName() {
+      return xp::nameOf(get_class($this));
+    }
+
+    /**
+     * Returns the runtime class of an object.
+     *
+     * @return  lang.XPClass runtime class
+     * @see     xp://lang.XPClass
+     */
+    public function getClass() {
+      return new XPClass($this);
+    }
+  }
+  // }}}
+
   // {{{ final class xp
+  //     Bootstrapping and registry
   final class xp {
     const CLASS_FILE_EXT= '.class.php';
 

--- a/core/src/main/php/lang/Object.class.php
+++ b/core/src/main/php/lang/Object.class.php
@@ -14,8 +14,8 @@
    * @purpose  Base class for all others
    */
   class Object implements Generic {
-    public $__id;
-    
+    use __xp;
+
     /**
      * Cloning handler
      *
@@ -23,131 +23,6 @@
     public function __clone() {
       if (!$this->__id) $this->__id= microtime();
       $this->__id= microtime();
-    }
-
-    /**
-     * Static field read handler
-     *
-     */
-    public static function __getStatic($name) {
-      if ("\7" === $name{0}) {
-        $t= debug_backtrace();
-        return eval('return '.$t[1]['args'][0][0].'::$'.substr($name, 1).';');
-      }
-      return NULL;
-    }
-
-    /**
-     * Static field read handler
-     *
-     */
-    public static function __setStatic($name, $value) {
-      if ("\7" === $name{0}) {
-        $t= debug_backtrace();
-        eval($t[1]['args'][0][0].'::$'.substr($name, 1).'= $value;');
-        return;
-      }
-    }
-
-    /**
-     * Static method handler
-     *
-     */
-    public static function __callStatic($name, $args) {
-      if ("\7" === $name{0}) {
-        $t= debug_backtrace();
-        return call_user_func_array(array($t[1]['args'][0][0], substr($name, 1)), $args);
-      }
-      $t= debug_backtrace();
-      throw new Error('Call to undefined method '.$t[1]['class'].'::'.$name);
-    }
-
-    /**
-     * Field read handler
-     *
-     */
-    public function __get($name) {
-      if ("\7" === $name{0}) {
-        return $this->{substr($name, 1)};
-      }
-      return NULL;
-    }
-
-    /**
-     * Field write handler
-     *
-     */
-    public function __set($name, $value) {
-      if ("\7" === $name{0}) {
-        $this->{substr($name, 1)}= $value;
-        return;
-      }
-      $this->{$name}= $value;
-    }
-    
-    /**
-     * Method handler
-     *
-     */
-    public function __call($name, $args) {
-      if ("\7" === $name{0}) {
-        return call_user_func_array(array($this, substr($name, 1)), $args);
-      }
-      $t= debug_backtrace();
-      $i= 1; $s= sizeof($t);
-      while ($i++ < $s && !isset($t[$i]['class'])) { }
-      $scope= $t[$i]['class'];
-      if (isset(xp::$registry['ext'][$scope])) {
-        foreach (xp::$registry['ext'][$scope] as $type => $class) {
-          if (!$this instanceof $type || !method_exists($class, $name)) continue;
-          array_unshift($args, $this);
-          return call_user_func_array(array($class, $name), $args);
-        }
-      }
-      throw new Error('Call to undefined method '.$this->getClassName().'::'.$name.'() from scope '.xp::nameOf($scope));
-    }
-
-    /**
-     * Returns a hashcode for this object
-     *
-     * @return  string
-     */
-    public function hashCode() {
-      if (!$this->__id) $this->__id= microtime();
-      return $this->__id;
-    }
-    
-    /**
-     * Indicates whether some other object is "equal to" this one.
-     *
-     * @param   lang.Generic cmp
-     * @return  bool TRUE if the compared object is equal to this object
-     */
-    public function equals($cmp) {
-      if (!$cmp instanceof Generic) return FALSE;
-      if (!$this->__id) $this->__id= microtime();
-      if (!$cmp->__id) $cmp->__id= microtime();
-      return $this === $cmp;
-    }
-    
-    /** 
-     * Returns the fully qualified class name for this class 
-     * (e.g. "io.File")
-     * 
-     * @return  string fully qualified class name
-     */
-    public function getClassName() {
-      return xp::nameOf(get_class($this));
-    }
-
-    /**
-     * Returns the runtime class of an object.
-     *
-     * @return  lang.XPClass runtime class
-     * @see     xp://lang.XPClass
-     */
-    public function getClass() {
-      return new XPClass($this);
     }
     
     /**

--- a/core/src/main/php/lang/Throwable.class.php
+++ b/core/src/main/php/lang/Throwable.class.php
@@ -18,8 +18,7 @@
    * @purpose  Base class
    */
   class Throwable extends Exception implements Generic {
-    public
-      $__id;
+    use __xp;
 
     public 
       $cause    = NULL,
@@ -237,48 +236,6 @@
       }
       
       return $s;
-    }
-
-    /**
-     * Returns a hashcode for this object
-     *
-     * @return  string
-     */
-    public function hashCode() {
-      return $this->__id;
-    }
-    
-    /**
-     * Indicates whether some other object is "equal to" this one.
-     *
-     * @param   lang.Generic cmp
-     * @return  bool TRUE if the compared object is equal to this object
-     */
-    public function equals($cmp) {
-      if (!$cmp instanceof Generic) return FALSE;
-      if (!$this->__id) $this->__id= microtime();
-      if (!$cmp->__id) $cmp->__id= microtime();
-      return $this === $cmp;
-    }
-    
-    /** 
-     * Returns the fully qualified class name for this class 
-     * (e.g. "io.File")
-     * 
-     * @return  string fully qualified class name
-     */
-    public function getClassName() {
-      return xp::nameOf(get_class($this));
-    }
-
-    /**
-     * Returns the runtime class of an object.
-     *
-     * @return  lang.XPClass runtime class
-     * @see     xp://lang.XPClass
-     */
-    public function getClass() {
-      return new XPClass($this);
     }
   }
 ?>


### PR DESCRIPTION
For an XP Framework version with a dependency on 5.4: 
- Implement root objects' methods with a trait instead of having them in both `Object` and `Throwable`
