### PR TITLE
Fix timeout handling in BSDSocket::connect()

### DIFF
--- a/core/ChangeLog
+++ b/core/ChangeLog
@@ -27,6 +27,8 @@ RFCs
 
 Bugfixes
 ~~~~~~~~
+- Fixed peer.BSDSocket connect timout
+  (ohinckel)
 - Fixed rdbms.DSN::equals() method to no longer regard differing observer
   params as equal
   (friebe)

--- a/core/src/main/php/peer/BSDSocket.class.php
+++ b/core/src/main/php/peer/BSDSocket.class.php
@@ -165,6 +165,9 @@
           socket_set_option($this->_sock, $level, $name, $value);
         }
       }
+      
+      // ... and timeouts
+      $this->setTimeout($timeout);
 
       // ...and connect it
       switch ($this->domain) {
@@ -198,8 +201,6 @@
         xp::gc(__FILE__);
         throw $e;
       }
-      
-      $this->setTimeout($this->_timeout);
       return TRUE;
     }
     


### PR DESCRIPTION
While releasing a new XP RC version I noticed that the tests hang at some point for a while. The reason is a test which tests the `peer.BSDSocket` functionality by starting a server locally and connecting to them. There are also tests which test `connec()`ting to wrong port using a short timeout (0.1 sec). But the connection timeout is not used and the tests stuck at this point.

There are two problems which are the cause of the problem:
- the timeout is set at the end of the function `peer.BSDSocket::connect()`
- the timeout is set to a wrong value since it uses `$this->_timeout` instead of the argument passed to `peer.BSDSocket::connect()` which is `$timeout`

It seems the problem exists since ~2009 where the timeout handling was refactored a little bit.
