### PR TITLE
Date::now() can accept TimeZone, Date::create() will throw exception for invalid arguments.

### DIFF
--- a/core/src/main/php/util/Date.class.php
+++ b/core/src/main/php/util/Date.class.php
@@ -129,8 +129,22 @@
       if ($tz) {
         date_timezone_set($date, $tz->getHandle());
       }
-      date_date_set($date, $year, $month, $day);
-      date_time_set($date, $hour, $minute, $second);
+           
+      if (FALSE === @date_date_set($date, $year, $month, $day) || 
+        FALSE === @date_time_set($date, $hour, $minute, $second)
+      ) {
+        throw new IllegalArgumentException(
+          sprintf('One or more given arguments ar not valid:
+          	$year=%s, $month=%s, $day= %s, $hour=%s, $minute=%s, $second=%s',
+            $year, 
+            $month, 
+            $day, 
+            $hour, 
+            $minute, 
+            $second 
+          )
+        );
+      }
       
       return new self($date);
     }
@@ -167,8 +181,8 @@
      *
      * @return  util.Date
      */
-    public static function now() {
-      return new self(NULL);
+    public static function now(TimeZone $tz= NULL) {
+      return new self(NULL, $tz);
     }
     
     /**

--- a/core/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
@@ -460,5 +460,42 @@
       } catch (IllegalArgumentException $expected) { }
       Date::now();
     }
+    
+    /**
+     * Test Date::create function with empty string's as arguments
+     *
+     */
+    #[@test, @expect('lang.IllegalArgumentException')]
+    public function dateCreateWithAllInvalidArguments() {
+      Date::create('', '', '', '', '', '');
+    }
+    
+    /**
+     * Test Date::create function with empty string's as arguments
+     *
+     */
+    #[@test, @expect('lang.IllegalArgumentException')]
+    public function dateCreateWithInvalidArgumentsExceptTimeZone() {
+      Date::create('', '', '', '', '', '', new TimeZone('UTC'));
+    }
+    
+    /**
+     * Create new date from static Date::now() without TimeZone param
+     *
+     */
+    #[@test]
+    public function createDateFromStaticNowFunctionWithoutParam() {
+      $this->assertEquals(TRUE, Date::now() instanceof Date);
+    }
+    
+    /**
+     * Create new date from static Date::now() with TimeZone param
+     *
+     */
+    #[@test]
+    public function createDateFromStaticNowFunctionWithZimeZone() {
+      $d= Date::now(new TimeZone('Australia/Sydney'));
+      $this->assertEquals('Australia/Sydney', $d->getTimeZone()->getName());
+    }
   }
 ?>


### PR DESCRIPTION
Hi,

This pull request fix the following things:
1. Date::now() can accept TimeZone at creation time
2. Fix bug in Date::create()
   -  the date was created if no arguments was passed ( with the value of Date::now())
     This is misleading because you can use the Date::create() with arguments and expect an error if the values are not valid.
     On the second point, maybe this was the desired intent.

All the test passed and I added a few for the modification.

What do you think ?

Have a nice day,
Cosmin
