### PR TITLE
fix for #112

### DIFF
--- a/core/src/main/php/webservices/xmlrpc/XmlRpcDecoder.class.php
+++ b/core/src/main/php/webservices/xmlrpc/XmlRpcDecoder.class.php
@@ -35,6 +35,12 @@
      * @throws  xml.XMLFormatException
      */
     protected function _unmarshall(Node $node) {
+
+      // value without type is supposed to be string (XML-RPC specs)
+      if('value' == $node->getName() && !isset($node->children[0])) {
+        return (string)$node->getContent();
+      }
+
       if (!isset($node->children[0])) {
         throw new XMLFormatException('Tried to access nonexistant node.');
       }


### PR DESCRIPTION
i'm not 100% certain the check for the name of the element is required, it's quite possible that _unmarshall will only be called for value elements, but i could not find unittests for this, so i decided to go for the safe way.
