### PR TITLE
Json serialization for Generic objects

### DIFF
--- a/core/src/main/php/webservices/json/JsonDecoder.class.php
+++ b/core/src/main/php/webservices/json/JsonDecoder.class.php
@@ -222,6 +222,20 @@
             $stream->write('"'.$this->escape((string)$data->getBytes('utf-8')).'"');
             break;
           }
+
+          if ($data instanceof Generic) {
+          
+            if (!method_exists($data, '__sleep')) {
+              $vars= get_object_vars($data);
+            } else {
+              $vars= array();
+              foreach ($data->__sleep() as $var) $vars[$var]= $data->{$var};
+            }
+            
+            $this->encodeTo($vars, $stream);
+            return TRUE;
+          }
+          
           // Break missing intentially
         }
         

--- a/core/src/test/php/net/xp_framework/unittest/json/JsonDecodingTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/json/JsonDecodingTest.class.php
@@ -923,5 +923,24 @@
         }')
       );
     }
+    
+    /**
+     * Test encoding of object
+     *
+     */
+    #[@test]
+    public function encodeObject() {
+      $o= ClassLoader::defineClass('JsonTestValueClass', 'lang.Object', array(), '{
+        public $prop  = NULL;
+      }')->newInstance();
+
+      $o->__id= '<bogusid>';
+      $o->prop= 'prop';
+
+      $this->assertEquals(
+        '{ "prop" : "prop" , "__id" : "<bogusid>" }',
+        $this->decoder->encode($o)
+      );
+    }    
   }
 ?>


### PR DESCRIPTION
Hi,

I just re-added into Json Encoder the feature to serialise XP-Framework Generic objects. It was removed by mistake (I think) sometime ago. A test for this was added also.

Regards,
Mihai
