### PR TITLE
Don't access scriptlet.HttpScriptletRequest::params public property, use setters and getters instead

### DIFF
--- a/core/src/main/php/scriptlet/HttpScriptlet.class.php
+++ b/core/src/main/php/scriptlet/HttpScriptlet.class.php
@@ -168,7 +168,7 @@
         case HttpConstants::POST:
         case HttpConstants::PUT: {
           if (!empty($_FILES)) {
-            $request->params= array_merge($request->params, $_FILES);
+            $request->setParams(array_merge($request->getParams(), $_FILES));
           }
           
           // Break missing intentionally

--- a/core/src/main/php/scriptlet/xml/XMLScriptlet.class.php
+++ b/core/src/main/php/scriptlet/xml/XMLScriptlet.class.php
@@ -203,7 +203,7 @@
       $response->hasStylesheet() || $this->_setStylesheet($request, $response);
 
       // Add all request parameters to the formvalue node
-      foreach ($request->params as $key => $value) {
+      foreach ($request->getParams() as $key => $value) {
         $response->addFormValue($key, $value);
       }
     }

--- a/core/src/main/php/scriptlet/xml/workflow/AbstractState.class.php
+++ b/core/src/main/php/scriptlet/xml/workflow/AbstractState.class.php
@@ -59,8 +59,8 @@
         // posted via request to avoid duplicate parameters. We do not need
         // to use $response->addFormValue() because this is done in
         // XMLScriptlet::processRequest() called in XMLScriptlet::doGet().
-        if (isset($request->params[$key])) continue;
-        $request->params[$key]= $handler->values[HVAL_FORMPARAM][$key];
+        if ($request->hasParam($key)) continue;
+        $request->setParam($key, $handler->values[HVAL_FORMPARAM][$key]);
       }
       
       // Add wrapper parameter representation if the handler has a wrapper

--- a/core/src/main/php/scriptlet/xml/workflow/Wrapper.class.php
+++ b/core/src/main/php/scriptlet/xml/workflow/Wrapper.class.php
@@ -62,7 +62,7 @@
         //
         // Note: This will only happen when the handler itself is set up.
         if (isset($definitions[self::PARAM_DEFAULT]) && '' == $request->getParam($name, '')) {
-          $request->params[$name]= $definitions[self::PARAM_DEFAULT];
+          $request->setParam($name, $definitions[self::PARAM_DEFAULT]);
         }
         
         // If this is a pass-behind value, register it to the handler's 
@@ -70,7 +70,7 @@
         // session (where it has been registered to during this call)
         // rather than from the request data (GET / POST / COOKIE).
         if ($definitions[self::PARAM_OCCURRENCE] & self::OCCURRENCE_PASSBEHIND) {
-          $handler->setValue($name, $request->params[$name]);
+          $handler->setValue($name, $request->getParam($name));
         }
       } 
     }


### PR DESCRIPTION
Hi,

There is an issue when accessing the public property `params` directly because the protected property `paramlookup` is not synced anymore: see the implementation of `scriptlet.HttpScriptletRequest::setParam()`:

```
/**
 * Sets a request parameter
 *
 * @param   string name Parameter name
 * @param   var value
 */
public function setParam($name, $value) {
  $l= strtolower($name);
  if (isset($this->paramlookup[$l])) {
    $name= $this->paramlookup[$l];
  } else {
    $this->paramlookup[$l]= $name;
  }
  $this->params[$name]= $value;
}
```

Maybe we should set `params` property protected aswell.

Let me know what you think,

Cheers,
Cosmin
