### PR TITLE
Use peer.URL::getCanonicalURL() instead of peer.URL::getURL()

### DIFF
--- a/core/src/main/php/peer/http/CurlHttpTransport.class.php
+++ b/core/src/main/php/peer/http/CurlHttpTransport.class.php
@@ -43,7 +43,7 @@
      */
     public function send(HttpRequest $request, $timeout= 60, $connecttimeout= 2.0) {
       $curl= curl_copy_handle($this->handle);
-      curl_setopt($curl, CURLOPT_URL, $request->url->getCanonicalUrl());
+      curl_setopt($curl, CURLOPT_URL, $request->url->getCanonicalURL());
       curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $request->getRequestString());
       curl_setopt($curl, CURLOPT_TIMEOUT, $timeout);
       


### PR DESCRIPTION
Hi,

This fix depends on pull request #140.
This will fix CurlHttpTransport in case of a secured URL which contains version number. 
We have the following use case:

```
$curl= curl_init();
curl_setopt($curl, CURLOPT_SSLVERSION, 3);
curl_setopt($curl, CURLOPT_URL, 'https+v3://localhost');
$response= curl_exec($curl);

if (FALSE === $response) print_r(curl_error($curl));
```

The following code sequence will output `Protocol https+v3 not supported or disabled in libcurl`.

What do you say?

Cheers,
Mihai
