### PR TITLE
Inject HttpRequestAdapter/HttpResponseAdapter into webmethods

### DIFF
--- a/core/src/main/php/webservices/rest/server/routing/RestRoutingProcessor.class.php
+++ b/core/src/main/php/webservices/rest/server/routing/RestRoutingProcessor.class.php
@@ -106,10 +106,17 @@
           $ref= array_search($ref, $names);
         }
         
+        // Do not un-serialize object instances
+        $binding= $this->getBinding($name);
+        if ($binding instanceof Generic) {
+          $args[(int)$ref]= $binding;
+          continue;
+        }
+        
         // Try to convert binding to requested argument type
         try {
           $args[(int)$ref]= $this->dataCaster->complex(
-            $this->dataCaster->simple($this->getBinding($name)),
+            $this->dataCaster->simple($binding),
             $routing->getArgs()->getArgumentType($names[$ref])
           );
         } catch (XPException $e) {


### PR DESCRIPTION
Hi,

As a short introduction, the bindings list of routing processor contains two object instances (`webservices.rest.server.transport.HttpRequestAdapter` and `webservices.rest.server.transport.HttpRequestAdapter`) and the `payload` which may contain a serialized object.

This fix solve two problems:
1. The actual implementation does not allow you to inject the request/response adapter into webmethod. The simple use case could be when a request header is needed into a webmethod. Think to the situation when your Rest API needs an authentication to a back-end, and the Authorization header is needed.

``` php
<?php
#[@webmethod(verb= 'GET', path= "/lists", inject= array('webservices.rest.server.transport.HttpRequestAdapter'))]
public function handleSaveIncidents($request) {
  return $request->getHeader('Authorization');
}
?>
```
1. If you try to inject the request/response adapter into webmethod, you will get an `ClassCastException` because the existing instance cannot be casted to `lang.Object`.

What do you say?

Cheers,
Mihai
