### PR TITLE
Some improvements of the RestDataCaster

### DIFF
--- a/core/src/main/php/webservices/rest/server/RestDataCaster.class.php
+++ b/core/src/main/php/webservices/rest/server/RestDataCaster.class.php
@@ -175,6 +175,9 @@
             foreach ($type->getFields() as $field) {
               if ($field->getModifiers() & MODIFIER_PUBLIC) {
                 if (!isset($data[$field->getName()])) {
+                  if($this->ignoreNullFields) {
+                    continue;
+                  }
                   throw new ClassCastException('Field '.$field->getName().' missing for '.$type->getName());
                 }
                 
@@ -185,6 +188,9 @@
                 
               } else if ($type->hasMethod('set'.ucfirst($field->getName()))) {
                 if (!isset($data[$field->getName()])) {
+                  if($this->ignoreNullFields) {
+                    continue;
+                  }
                   throw new ClassCastException('Field '.$field->getName().' missing for '.$type->getName());
                 }
                 

--- a/core/src/test/php/net/xp_framework/unittest/rest/server/RestDataCasterTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rest/server/RestDataCasterTest.class.php
@@ -370,6 +370,58 @@
     }
 
     /**
+     * Test complexify hashmap as object with optional fields
+     *
+     */
+    #[@test]
+    public function complexifyHashMapAsObjectOptionalFields() {
+      $this->sut->setIgnoreNullFields(TRUE);
+
+      $casted= $this->sut->complex(array('one' => '4', /* two is missing */ 'three' => '5'), self::$objThreeFields->getClass());
+
+      $this->assertEquals('4', $casted->one);
+      $this->assertEquals(self::$arrayThreeHash['two'], $casted->two);
+      $this->assertEquals('5', $casted->three);
+    }
+
+    /**
+     * Test complexify hashmap as object with missing fields
+     *
+     */
+    #[@test, @expect('lang.ClassCastException')]
+    public function complexifyHashMapAsObjectMissingFields() {
+      $this->sut->setIgnoreNullFields(FALSE);
+
+      $casted= $this->sut->complex(array('one' => '4', /* two is missing */ 'three' => '5'), self::$objThreeFields->getClass());
+    }
+
+    /**
+     * Test complexify hashmap as object with private attributes and optional fields
+     *
+     */
+    #[@test]
+    public function complexifyHashMapAsObjectOptionalPrivateFields() {
+      $this->sut->setIgnoreNullFields(TRUE);
+
+      $casted= $this->sut->complex(array('one' => '4', /* two is missing */ 'three' => '5'), self::$objThreeMethods->getClass());
+
+      $this->assertEquals('4', $casted->getOne());
+      $this->assertEquals(self::$arrayThreeHash['two'], $casted->getTwo());
+      $this->assertEquals('5', $casted->getThree());
+    }
+
+    /**
+     * Test complexify hashmap as object with private attributes missing fields
+     *
+     */
+    #[@test, @expect('lang.ClassCastException')]
+    public function complexifyHashMapAsObjectMissingPrivateFields() {
+      $this->sut->setIgnoreNullFields(FALSE);
+
+      $casted= $this->sut->complex(array('one' => '4', /* two is missing */ 'three' => '5'), self::$objThreeMethods->getClass());
+    }
+
+    /**
      * Test complexify hashmap
      * 
      */


### PR DESCRIPTION
Hi,

I've made some changes in the RestDataCaster.
- added support for MapType
- now you can cast arrays into objects, which contain arrays. (This didn't work before because e.g. 'lang.types.String[]' is no XPClass. So I've replaced it with Type.)
- Make all fields optional, if the the flag $ignoreNullFields is TRUE

The last point may be a behavior change in the caster, because all fields were required before. So now it would be the issue of the user to check, if all necessary fields are set.
