### PR TITLE
Fix stacktrace scope when calling an undefined method using call_user_func_array()

### DIFF
--- a/core/src/main/php/lang/Object.class.php
+++ b/core/src/main/php/lang/Object.class.php
@@ -94,11 +94,18 @@
         return call_user_func_array(array($this, substr($name, 1)), $args);
       }
       $t= debug_backtrace();
+
+      // Get self
       $i= 1; $s= sizeof($t);
       while (!isset($t[$i]['class']) && $i++ < $s) { }
       $self= $t[$i]['class'];
-      $scope= $t[$i+ 1]['class'];
-      if (isset(xp::$registry['ext'][$scope])) {
+
+      // Get scope
+      $i++;
+      while (!isset($t[$i]['class']) && $i++ < $s) { }
+      $scope= isset($t[$i]['class']) ? $t[$i]['class'] : NULL;
+
+      if (NULL != $scope && isset(xp::$registry['ext'][$scope])) {
         foreach (xp::$registry['ext'][$scope] as $type => $class) {
           if (!$this instanceof $type || !method_exists($class, $name)) continue;
           array_unshift($args, $this);

--- a/core/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/ObjectTest.class.php
@@ -139,5 +139,25 @@
         $o->toString()
       );
     }
+
+    /**
+     * Tests call to undefined method
+     *
+     * @see     xp://lang.Object#__call
+     */
+    #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
+    public function callUndefinedMethod() {
+      create(new Object())->undefMethod();
+    }
+
+    /**
+     * Tests call to undefined method using call_user_func_array()
+     *
+     * @see     xp://lang.Object#__call
+     */
+    #[@test, @expect(class= 'lang.Error', withMessage= '/Call to undefined method .+::undefMethod\(\) from scope net\.xp_framework\.unittest\.core\.ObjectTest/')]
+    public function callUndefinedMethod_call_user_func_array() {
+      call_user_func_array(array(new Object(), 'undefMethod'), array());
+    }
   }
 ?>


### PR DESCRIPTION
When using call_user_func_array(), an extra entry is added to the output of debug_backtrace(). This pull request tries to skip forward past this entry so that you get the same exception if you're calling:

```
create(new Object())->undefMethod();
```

or

```
call_user_func_array(array(new Object(), 'undefMethod'), array());
```

Let me know what you guys think.

Cheers,
-- Marius
