### PR TITLE
Wrapper: Load pass-behind params from session & remove un-needed $context param

### DIFF
--- a/core/src/main/php/scriptlet/xml/workflow/Wrapper.class.php
+++ b/core/src/main/php/scriptlet/xml/workflow/Wrapper.class.php
@@ -69,7 +69,7 @@
         // session (where it has been registered to during this call)
         // rather than from the request data (GET / POST / COOKIE).
         if (($definitions[self::PARAM_OCCURRENCE] & self::OCCURRENCE_PASSBEHIND)
-            && (NULL!==$request->session)
+            && NULL !== $request->session
             && $request->session->hasValue($name)
         ) {
           $handler->setValue($name, $request->session->getValue($name));


### PR DESCRIPTION
Hi,

I'm not sure if this is the right behaviour, but in the old version, the pass-behind parameters are loaded from request object. As the code comment say, the values should be loaded from the session. Maybe I miss something here.. Should I expect to find there (in the request) the session values? (if yes, I don't think is the right way..).

Also, the $context method argument isn't used inside the function, it's useless.

If I'm wrong, sorry for spam,
Mihai
