### PR TITLE
Fix encoding for AbstractHttpRequestAdapter::getQueryString()

### DIFF
--- a/core/src/main/php/webservices/rest/server/transport/AbstractHttpRequestAdapter.class.php
+++ b/core/src/main/php/webservices/rest/server/transport/AbstractHttpRequestAdapter.class.php
@@ -67,7 +67,7 @@
      * @return string
      */
     public function getQueryString() {
-      return $this->request->getQueryString();
+      return $this->request->getUrl()->getQuery();
     }
   }
 ?>

--- a/core/src/test/php/net/xp_framework/unittest/rest/server/transport/AbstractHttpRequestAdapterTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rest/server/transport/AbstractHttpRequestAdapterTest.class.php
@@ -89,5 +89,29 @@
       $this->request->setParam('test', 'test value');
       $this->assertEquals('test value', $this->fixture->getParam('test'));
     }
+    
+    /**
+     * Test getQueryString()
+     *  
+     */
+    #[@test]
+    public function getQueryString() {
+      $this->request->setParam('product1', 'name&name');
+      $this->request->setParam('product2', 'test&test');
+      $this->assertEquals('product1=name%26name&product2=test%26test', $this->fixture->getQueryString());
+    }
+    
+    /**
+     * Test getQueryString()
+     *  
+     */
+    #[@test]
+    public function getQueryStringEqualWithHttpRequestQueryString() {
+      $this->request->env['QUERY_STRING']='product1=name%26name&product2=test%26test';
+      $this->request->setParam('product1', 'name&name');
+      $this->request->setParam('product2', 'test&test');
+      $this->assertNotEquals($this->request->getQueryString(), $this->fixture->getQueryString());
+      $this->assertEquals($this->request->getQueryString(), urldecode($this->fixture->getQueryString()));
+    }
   }
 ?>


### PR DESCRIPTION
Hi,

As title said, this fix the problem with decoded query string returned by `HttpScriptletRequest`. 

This is the use-case:

``` php
// Original query string
var_dump($_SERVER['QUERY_STRING']);
// product1=name%26name&product2=test%26test;

// Before fix
var_dump(AbstractHttpRequestAdapter::getQueryString()); 
// product1=name&name&product2=test&test

// After fix 
var_dump(AbstractHttpRequestAdapter::getQueryString()); 
// product1=name%26name&product2=test%26test

```

For this reason, RestRoutingProcessor::execute() will fail when is trying to process the arguments.

Cheers,
Mihai
