### PR TITLE
Creation of Date from a float value causes PHP fatal error

### DIFF
--- a/core/src/main/php/util/Date.class.php
+++ b/core/src/main/php/util/Date.class.php
@@ -44,7 +44,7 @@
     public function __construct($in= NULL, TimeZone $timezone= NULL) {
       if ($in instanceof DateTime) {
         $this->date= $in;
-      } else if (is_numeric($in) && (int)$in == $in) {
+      } else if ((string)(int)$in === (string)$in) {
         
         // Specially mark timestamps for parsing (we assume here that strings
         // containing only digits are timestamps)

--- a/core/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/util/DateTest.class.php
@@ -508,5 +508,38 @@
       $date= new Date('19.19');
       $this->assertEquals(strtotime('19.19'), $date->getTime());
     }
+
+   /**
+    * Test unix timestamp string
+    *
+    * @see http://www.php.net/manual/en/datetime.formats.time.php
+    */
+    #[@test]
+    public function testValidUnixTimestamp() {
+
+      $this->assertDateEquals('1970-01-01T00:00:00+00:00', new Date(0));
+      $this->assertDateEquals('1970-01-01T00:00:00+00:00', new Date('0'));
+
+      $this->assertDateEquals('1970-01-01T00:00:01+00:00', new Date(1));
+      $this->assertDateEquals('1970-01-01T00:00:01+00:00', new Date('1'));
+
+      $this->assertDateEquals('1969-12-31T23:59:59+00:00', new Date(-1));
+      $this->assertDateEquals('1969-12-31T23:59:59+00:00', new Date('-1'));
+
+      $this->assertDateEquals('1969-12-20T10:13:20+00:00', new Date(-1000000));
+      $this->assertDateEquals('1969-12-20T10:13:20+00:00', new Date('-1000000'));
+
+      $this->assertDateEquals('1970-01-12T13:46:40+00:00', new Date(1000000));
+      $this->assertDateEquals('1970-01-12T13:46:40+00:00', new Date('1000000'));
+    }
+
+   /**
+    * Test invalid time
+    *
+    */
+    #[@test, @expect('lang.IllegalArgumentException')]
+    public function testInvalidUnixTimestamp() {
+      new Date('+1000000');
+    }
   }
 ?>


### PR DESCRIPTION
Hello,

Creating Date from float values causes a fatal error. Eg:

``` php
$date= new Date('19.19');
```

Expected result would be a Date object with today's date, hour 19, minute 19.
For more details about the supported DateTime formats see http://www.php.net/manual/en/datetime.formats.php .

Kind regards,
Stefan.
