### PR TITLE
Add .travis.yml for building on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# This provides an initial configuration to
+# test xp-framework on http://travis-ci.org/
+
 language: php
 
 php:


### PR DESCRIPTION
This provides an initial configuration to test xp-framework on http://travis-ci.org/
- implement provisioning of local runners
- enable building on PHP 5.2, 5.3, 5.4
