### PR TITLE
Add parsing by quality for some http-headers as defined in HTTP/1.1 RFC 2616

### DIFF
--- a/core/src/main/php/scriptlet/HttpScriptletRequest.class.php
+++ b/core/src/main/php/scriptlet/HttpScriptletRequest.class.php
@@ -270,61 +270,11 @@
      */
     public function setHeaders($headers) {
       $this->headers= $this->headerlookup= array();
-      foreach(array('Content-Type', 'Accept', 'Accept-Encoding', 'Accept-Language', 'Accept-Charset') as $header_key) {
-        if(array_key_exists($header_key, $headers)) $headers[$header_key] = $this->parseQuality($headers[$header_key]); 
-      }
       foreach ($headers as $name => $value) {
         $this->addHeader($name, $value);
       }
     }
 
-    /**
-     * Parse Quality of Header-Entry.
-     *
-     * @param string header_value
-     * @return string the entry with highest quality
-     */
-    private function parseQuality($header_value) {
-        $candidate_map = array();
-
-        foreach(explode(',', $header_value) as $header_candidate) {
-            if(strstr($header_candidate, ';')) {
-                list($media_type, $quality) = $this->parseQualityBit($header_candidate); 
-                $map[$media_type] = $quality; 
-            } else {
-                // no quality, set q=1, as defined in RFC 2616
-                $map[$header_candidate] = 1; 
-            }
-        }
-        asort($map); 
-        $map = array_keys( $map); 
-        return trim( end( $map)); 
-    }
-
-    /** 
-     * Parse Quality Bit
-     * 
-     * @params string header_bit
-     * @return array [quality, value]
-     *
-     */ 
-    private function parseQualityBit($header_bit) {
-        $values = explode(';', $header_bit); 
-        // first key is value, next keys are options 
-        $media_type = array_shift($values); 
-        // the rest on the array should only foo=bar values 
-        foreach( $values as $value) {
-            $value = trim($value); 
-            if(strstr($value, '=')) {
-                list($qkey, $qval) = explode('=', $value, 2); 
-                $qval = (float) $qval; 
-                if($qkey == 'q') {
-                    return array($media_type, $qval); 
-                }
-            } 
-        }
-        return array($media_type, 0.1); 
-    }
 
     /**
      * Add single header - overwrites header if already set
@@ -414,6 +364,108 @@
      */
     public function isMultiPart() {
       return (bool)strstr($this->getHeader('Content-Type'), 'multipart/form-data');
+    }
+
+    /**
+     *  Returns the Accept Header by quality-param
+     *  
+     * @return php.stdClass
+     */
+    public function getAccept() {
+      return $this->parseQuality( $this->getHeader('Accept'));
+    }
+
+    /**
+     *  Returns the Accept-Charset Header by quality-param
+     *  
+     * @return php.stdClass
+     */
+    public function getAcceptCharset() {
+      return $this->parseQuality( $this->getHeader('Accept-Charset'));
+    }
+
+    /**
+     *  Returns the Accept-Encoding Header by quality-param
+     *  
+     * @return php.stdClass
+     */
+    public function getAcceptEncoding() {
+      return $this->parseQuality( $this->getHeader('Accept-Encoding'));
+    }
+
+    /**
+     *  Returns the Accept-Language Header by quality-param
+     *  
+     * @return php.stdClass
+     */
+    public function getAcceptLanguage() {
+      return $this->parseQuality( $this->getHeader('Accept-Language'));
+    }
+
+    /**
+     * Parse Quality of Header-Entry.
+     *
+     * @param string header_value
+     * @return php.stdClass 
+     */
+    private function parseQuality($header_value) {
+      $candidate_map = array();
+
+      foreach (explode(',', $header_value) as $header_candidate) {
+        if (strstr($header_candidate, ';')) {
+          list ($media_type, $quality) = $this->parseQualityBit($header_candidate); 
+          $map[trim($media_type)] = $quality; 
+        } else {
+          // no quality, set q=1, as defined in RFC 2616
+          $map[trim($header_candidate)] = 1; 
+        }
+      }
+
+      asort($map); 
+      $map_obj  = new stdClass();
+      $map_keys = array_keys($map); 
+
+      $map_obj->best_type  = end( $map_keys); 
+      $map_obj->all_types  = $map_keys; 
+      $map_obj->list       = array();
+
+      foreach (array_reverse($map) as $mapk => $mapv) {
+        $mapo             = new stdClass();
+        $mapo->type       = $mapk; 
+        $mapo->quality    = $mapv;
+        $map_obj->list[]  = $mapo; 
+      }
+
+      return $map_obj; 
+    }
+
+    /** 
+     * Parse Quality Bit
+     * 
+     * @params string header_bit
+     * @return array [quality, value]
+     *
+     */ 
+    private function parseQualityBit($header_bit) {
+      $values = explode(';', $header_bit); 
+
+      // first key is value, next keys are options 
+      $media_type = array_shift($values); 
+
+      // the rest on the array should only foo=bar values 
+      foreach ( $values as $value) {
+        $value = trim($value); 
+
+        if (strstr($value, '=')) {
+          list ($qkey, $qval) = explode('=', $value, 2); 
+
+          if ($qkey == 'q') {
+            $qval = (float) $qval; 
+            return array($media_type, $qval); 
+          }
+        } 
+      }
+      return array($media_type, 1); 
     }
   }
 ?>

--- a/core/src/test/php/net/xp_framework/unittest/scriptlet/HttpScriptletRequestTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/scriptlet/HttpScriptletRequestTest.class.php
@@ -428,79 +428,78 @@
     }
 
     /**
-     * Test setHeader() with quality params on Accept
+     * Test getHeader() yield
      *
      */
     #[@test]
-    public function testHeaderWithQualityParamOnAccept() {
+    public function getHeaderYield() {
+      $r= $this->newRequest('GET', 'http://localhost/', array());
+      $r->setHeaders(array(
+        'Accept' => 'application/json, */*; q=0.01, application/json'
+      ));
+      $this->assertEquals(
+        'application/json, */*; q=0.01, application/json', 
+        $r->getHeader('Accept')
+      );
+    }
+
+    /**
+     * Test getAccept() with quality params on Accept
+     *
+     */
+    #[@test]
+    public function getAcceptWithQualityParamOnAccept() {
       $r= $this->newRequest('GET', 'http://localhost/', array());
       $r->setHeaders(array(
         'Accept' => 'application/json, */*; q=0.01, application/json'
       ));
       
-      $this->assertEquals('application/json', $r->getHeader('Accept'));
+      $this->assertEquals('application/json', $r->getAccept()->best_type);
+      $this->assertEquals(2, count( $r->getAccept()->list));
+      $this->assertObject($r->getAccept()->list[0]); 
+      $this->assertEquals(
+        "php.stdClass {\n  type => \"application/json\"\n  quality => 1\n}", 
+        xp::stringOf($r->getAccept()->list[0])
+      );
     }
 
     /**
-     * Test setHeader() with more complex quality params on Accept without whitespaces
+     * Test getAccept() with more complex quality params on Accept without whitespaces
      *
-     * @see http://shiflett.org/blog/2011/may/the-accept-header
      */
     #[@test]
-    public function testHeaderWithMoreComplexQualityParamsOnAcceptWithoutWhitespaces() {
+    public function getAcceptWithComplexQualityNoWhitespaces() {
       $r= $this->newRequest('GET', 'http://localhost/', array());
       $r->setHeaders(array(
-        'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json'
+        'Accept' => 
+          'text/html,application/xml;q=0.9,*/*;q=0.8,application/json;q=0.7'
       ));
       
-      $this->assertEquals('text/html', $r->getHeader('Accept'));
+      $this->assertEquals('text/html', $r->getAccept()->best_type); 
+      $this->assertTrue( 
+        in_array( 'application/json', $r->getAccept()->all_types)
+      );
     }
 
     /**
-     * Test setHeader() with non-existent setted Header
-     *
-     */
-    #[@test]
-    public function testHeaderWithNonExistentHeader() {
-      $r= $this->newRequest('GET', 'http://localhost/', array());
-      $r->setHeaders(array( ));
-      
-      $this->assertEquals(null, $r->getHeader('Accept'));
-    }
-
-    /**
-     * Test setHeader() with null-byte injected
-     *
-     */
-    #[@test]
-    public function testHeaderWithNullByteInjected() {
-      $r= $this->newRequest('GET', 'http://localhost/', array());
-      $r->setHeaders(array(
-        'Accept' => 'text/html,application/xhtml+xml'.chr(0).',application/xml;q=0.9,*/*;q=0.8,application/json'
-      ));
-      
-      $this->assertEquals('text/html', $r->getHeader('Accept'));
-    }
-
-    /**
-     * Test setHeader() with complex header-data
+     * Test all getAccept*() methods
      *
      */
     #[@test]
     public function testHeaderWithMoreComplexData() {
       $r= $this->newRequest('GET', 'http://localhost/', array());
       $r->setHeaders(array(
-        'Accept' => 'text/css,*/*;q=0.1', 
-        'Accept-Charset' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.3', 
-        'Accept-Encoding' => 'gzip,deflate,sdch', 
+        'Accept'          => 'text/css,*/*;q=0.1', 
+        'Accept-Charset'  => 'ISO-8859-1,utf-8;q=1,*;q=0.3', 
+        'Accept-Encoding' => 'gzip,deflate;q=1,sdch', 
         'Accept-Language' => 'de-DE,de;q=0.8,en-US;q=0.6,en;q=0.4'
       ));
       
-      $this->assertEquals('text/css',   $r->getHeader('Accept'));
-      $this->assertEquals('ISO-8859-1', $r->getHeader('Accept-Charset'));
-      $this->assertEquals('gzip',       $r->getHeader('Accept-Encoding'));
-      $this->assertEquals('de-DE',      $r->getHeader('Accept-Language'));
-      
+      $this->assertEquals('text/css',   $r->getAccept()->best_type);
+      $this->assertEquals('ISO-8859-1', $r->getAcceptCharset()->best_type);
+      $this->assertEquals('gzip',       $r->getAcceptEncoding()->best_type);
+      $this->assertEquals('de-DE',      $r->getAcceptLanguage()->best_type);
+
     }
   }
 ?>


### PR DESCRIPTION
Some Browsers or JS-Libs like firefox or jQuery do send full qualified headers as defined in RFC 2616. 

This will throw an exception under some circumstances, for example:

```
Exception scriptlet.HttpScriptletException (406:The accept type is not supported: application/json, */*; q=0.01, application/json)
```

This work-around will return just the one entry, with the highest quality, as expected by the XP-Framework. 
