### PR TITLE
Support for REST Object collections [test]

### DIFF
--- a/core/src/resources/unittest/webservices.ini
+++ b/core/src/resources/unittest/webservices.ini
@@ -47,3 +47,6 @@ class="net.xp_framework.unittest.scriptlet.rpc.XmlRpcDecoderTest"
 
 [xmlrpc-encoder]
 class="net.xp_framework.unittest.scriptlet.rpc.XmlRpcEncoderTest"
+
+[rest-client]
+class="net.xp_framework.unittest.webservices.rest.RestClientExecutionTest"

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/Issues.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/Issues.class.php
@@ -1,0 +1,27 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$
+ */
+
+  $package= 'net.xp_framework.unittest.webservices.rest';
+  
+
+  /**
+   * Issue
+   *
+   */
+  class net·xp_framework·unittest·webservices·rest·Issues extends Object {
+    public $issues= NULL;
+    
+    /**
+     * Set issues
+     *
+     * @param   net·xp_framework·unittest·webservices·rest·IssueWithField[] issues
+     */
+    public function setIssues($issues) {
+      $this->issues= $issues;
+    }
+
+  }
+?>

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestClientExecutionTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestClientExecutionTest.class.php
@@ -8,6 +8,7 @@
     'unittest.TestCase',
     'webservices.rest.RestClient',
     'io.streams.MemoryInputStream',
+    'net.xp_framework.unittest.webservices.rest.Issues',
     'net.xp_framework.unittest.webservices.rest.IssueWithField',
     'net.xp_framework.unittest.webservices.rest.IssueWithUnderscoreField',
     'net.xp_framework.unittest.webservices.rest.IssueWithSetter',
@@ -200,5 +201,77 @@
       $this->assertEquals(new net·xp_framework·unittest·webservices·rest·IssueWithField(1, 'Found a bug'), $list[0]);
       $this->assertEquals(new net·xp_framework·unittest·webservices·rest·IssueWithField(2, 'Another'), $list[1]);
     }
+
+    /**
+     * Test if object collections are built as class fields
+     *
+     */
+    #[@test]
+    public function typedNestedArrayJsonContent() {
+      $fixture= $this->fixtureWith(
+          HttpConstants::STATUS_OK,
+          '{ "issues" : { "issue" : [ { "issue_id" : 1, "title" : "Found a bug" }, { "issue_id" : 2, "title" : "Another" } ] } }',
+          array('Content-Type' => 'application/json')
+      );
+      $class= Type::forName('net.xp_framework.unittest.webservices.rest.Issues');
+      $response= $fixture->execute($class, new RestRequest());
+      $list= $response->data();
+
+      $issueWithField1= new net·xp_framework·unittest·webservices·rest·IssueWithField(1, 'Found a bug');
+      $issueWithField2= new net·xp_framework·unittest·webservices·rest·IssueWithField(2, 'Another');
+
+      $issuesNest= new net·xp_framework·unittest·webservices·rest·Issues();
+      $issuesNest->setIssues(array($issueWithField1, $issueWithField2));
+
+      $this->assertInstanceOf('net·xp_framework·unittest·webservices·rest·Issues', $list);
+
+      $issues= $list->issues;
+      $this->assertArray($issues);
+
+      $this->assertEquals(2, count($issues));
+
+      $this->assertInstanceOf('net·xp_framework·unittest·webservices·rest·IssueWithField', $issues[0]);
+      $this->assertInstanceOf('net·xp_framework·unittest·webservices·rest·IssueWithField', $issues[1]);
+
+      $this->assertEquals($issueWithField1, $issues[0]);
+      $this->assertEquals($issueWithField2, $issues[1]);
+    }
+
+    
+    /**
+     * Test if object collections are built as class fields
+     *
+     */
+    #[@test]
+    public function typedNestedArrayXmlContent() {
+      $fixture= $this->fixtureWith(
+          HttpConstants::STATUS_OK,
+          '<issues><issue><issue_id>1</issue_id><title>Found a bug</title></issue><issue><issue_id>2</issue_id><title>Another</title></issue></issues>',
+          array('Content-Type' => 'text/xml')
+      );
+      $class= Type::forName('net.xp_framework.unittest.webservices.rest.Issues');
+      $response= $fixture->execute($class, new RestRequest());
+      $list= $response->data();
+    
+      $issueWithField1= new net·xp_framework·unittest·webservices·rest·IssueWithField(1, 'Found a bug');
+      $issueWithField2= new net·xp_framework·unittest·webservices·rest·IssueWithField(2, 'Another');
+    
+      $issuesNest= new net·xp_framework·unittest·webservices·rest·Issues();
+      $issuesNest->setIssues(array($issueWithField1, $issueWithField2));
+    
+      $this->assertInstanceOf('net·xp_framework·unittest·webservices·rest·Issues', $list);
+    
+      $issues= $list->issues;
+      $this->assertArray($issues);
+    
+      $this->assertEquals(2, count($issues));
+    
+      $this->assertInstanceOf('net·xp_framework·unittest·webservices·rest·IssueWithField', $issues[0]);
+      $this->assertInstanceOf('net·xp_framework·unittest·webservices·rest·IssueWithField', $issues[1]);
+    
+      $this->assertEquals($issueWithField1, $issues[0]);
+      $this->assertEquals($issueWithField2, $issues[1]);
+    }
+
   }
 ?>


### PR DESCRIPTION
These tests exemplify the case of nested objects as the following scenario:

class Issues has a member named $issues which should be an array of IssueWithField objects.

This is how the Issues object should look like:

``` php
object(net·xp_framework·unittest·webservices·rest·Issues)#1067 (2) {
  ["issues"]=>
  array(2) {
      [0]=>
      object(net·xp_framework·unittest·webservices·rest·IssueWithField) (2) {
        ["issue_id"]=>
        int(1)
        ["title"]=>
        string(11) "Found a bug"
      }
      [1]=>
      object(net·xp_framework·unittest·webservices·rest·IssueWithField) (2) {
        ["issue_id"]=>
        int(2)
        ["title"]=>
        string(7) "Another"
      }
    }
  }
}
```

However, right now it's being created with an undesired structure:

``` php
object(net·xp_framework·unittest·webservices·rest·Issues)#1067 (2) {
  ["issues"]=>
  array(1) {
    ["issue"]=>
    array(2) {
      [0]=>
      array(2) {
        ["issue_id"]=>
        int(1)
        ["title"]=>
        string(11) "Found a bug"
      }
      [1]=>
      array(2) {
        ["issue_id"]=>
        int(2)
        ["title"]=>
        string(7) "Another"
      }
    }
  }
}
```

These tests will fail.
