### PR TITLE
Use mxp-2.0.0 (pushed to central)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
+        <groupId>net.xp-forge.maven.plugins</groupId>
         <artifactId>maven-xpframework-plugin</artifactId>
-        <version>1.1</version>
+        <version>2.0.0</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>
@@ -50,9 +50,9 @@
 
   <!-- Source code management -->
   <scm>
-    <connection>scm:git:git@github.com:xp-framework/xp-framework.git</connection>
+    <connection>scm:git:git://github.com/xp-framework/xp-framework.git</connection>
     <developerConnection>scm:git:git@github.com:xp-framework/xp-framework.git</developerConnection>
-    <url>git@github.com:xp-framework/xp-framework.git</url>
+    <url>https://github.com/xp-framework/xp-framework</url>
   </scm>
 
 </project>


### PR DESCRIPTION
This pull request updates `pom.xml` to use `maven-xpframework-plugin v2.0.0`.

This plugin version has been pushed to Maven public central repository, so now Maven knows about it without the need to `mvn install` it first or alter your `~/.m2/settings.xml` to add custom repositories:

``` sh
~ $ sudo apt-get install maven2 git
~ $ git clone git@github.com:xp-framework/xp-framework.git
~ $ cd xp-framework
~ $ mvn package
```

Cheers,
-- Marius
