### PR TITLE
Allow _-.: as values in rest paths

### DIFF
--- a/core/src/main/php/webservices/rest/server/routing/RestPath.class.php
+++ b/core/src/main/php/webservices/rest/server/routing/RestPath.class.php
@@ -30,7 +30,7 @@
      */
     public function __construct($path) {
       static $search= '/\{([\w]*)\}/';
-      static $replace= '([%\w]*)';
+      static $replace= '([%\w:\-\.]*)';
       
       list ($this->path, $this->query)= $this->splitParams($path);
       

--- a/core/src/test/php/net/xp_framework/unittest/rest/server/routing/RestPathTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rest/server/routing/RestPathTest.class.php
@@ -147,5 +147,53 @@
         create(new RestPath('/path/to/item?filter={filter}&type={type}'))->match('/path/to/item?filter=red&type=color')
       );
     }
+
+    /**
+     * Test
+     *
+     */
+    #[@test]
+    public function underscoreAllowedInParam() {
+      $this->assertEquals(
+        array('token' => 'a_b'),
+        create(new RestPath('/path/to/{token}'))->match('/path/to/a_b')
+      );
+    }
+
+    /**
+     * Test
+     *
+     */
+    #[@test]
+    public function colonAllowedInParam() {
+      $this->assertEquals(
+        array('token' => 'a:b'),
+        create(new RestPath('/path/to/{token}'))->match('/path/to/a:b')
+      );
+    }
+
+    /**
+     * Test
+     *
+     */
+    #[@test]
+    public function dashAllowedInParam() {
+      $this->assertEquals(
+        array('token' => 'a-b'),
+        create(new RestPath('/path/to/{token}'))->match('/path/to/a-b')
+      );
+    }
+
+    /**
+     * Test
+     *
+     */
+    #[@test]
+    public function dotAllowedInParam() {
+      $this->assertEquals(
+        array('token' => 'a.b'),
+        create(new RestPath('/path/to/{token}'))->match('/path/to/a.b')
+      );
+    }
   }
 ?>


### PR DESCRIPTION
- developed w/ Jörg Wasmer
- this pull request allows usage of _-.: as valid values in a rest path segment
