### PR TITLE
Add helper functions to lang.Enum to retrieve values

### DIFF
--- a/core/src/main/php/lang/Enum.class.php
+++ b/core/src/main/php/lang/Enum.class.php
@@ -122,5 +122,40 @@
       }
       return $r;
     }
+    
+    /**
+     * Return value for given name
+     * 
+     * @param string name The name of value
+     * @return self
+     */
+    public static function getByName($name) {
+      return self::valueOf(new XPClass(get_called_class()), $name);
+    }
+    
+    /**
+     * Return value for given ordina value
+     * 
+     * @param int ordinal The ordinal of value
+     * @return self
+     */
+    public static function getByOrdinal($ordinal) {
+      $class= new XPClass(get_called_class());
+      
+      foreach (self::valuesOf($class) as $value) {
+        if ($value->ordinal() == $ordinal) return $value;
+      }
+      
+      throw new IllegalArgumentException('No such member '.$ordinal.' in '.$class->getName());
+    }
+    
+    /**
+     * Return all available values for given enum
+     * 
+     * @return self[] 
+     */
+    public static function values() {
+      return self::valuesOf(new XPClass(get_called_class()));
+    }
   }
 ?>

--- a/core/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/EnumTest.class.php
@@ -294,6 +294,55 @@
     public function valuesOfNonEnum() {
       Enum::valuesOf($this);
     }
+    
+    /**
+     * Test Enum::getByName() method
+     *  
+     */
+    #[@test]
+    public function getByName() {
+      $this->assertEquals(Coin::$penny, Coin::getByName('penny'));
+    }
+    
+    /**
+     * Test Enum::getByName() method with wrong name
+     * 
+     */
+    #[@test, @expect(class= 'lang.IllegalArgumentException', withMessage= 'Class Coin does not have a property named invalid')]
+    public function getByNameWithWrongName() {
+      Coin::getByName('invalid');
+    }
+    
+    /**
+     * Test Enum::getByOrdinal() method
+     * 
+     */
+    #[@test]
+    public function getByOrdinal() {
+      $this->assertEquals(Coin::$penny, Coin::getByOrdinal(1));
+    }
+    
+    /**
+     * Test Enum::getByOrdinal() method with wrong value
+     *  
+     */
+    #[@test, @expect(class= 'lang.IllegalArgumentException', withMessage= 'No such member -1 in net.xp_framework.unittest.core.Coin')]
+    public function getByOrdinalWithWrongValue() {
+      Coin::getByOrdinal(-1);
+    }
+    
+    /**
+     * Test Enum::values()
+     * 
+     */
+    #[@test]
+    public function values() {
+      $values= Coin::values();
+      
+      $this->assertArray($values);
+      $this->assertTrue(sizeof($values) > 0);
+      $this->assertClass($values[0], 'net.xp_framework.unittest.core.Coin');
+    }
 
     /**
      * Test Operation::$plus


### PR DESCRIPTION
The most enum classes already have helper functions implemented to retrieve the elements by name or ordinal value. These functions make use of the `lang.Enum`s helper functions `lang.Enum::valueOf()` or `lang.Enum::valuesOf()` to get the values. It was not possible to have these helper function in the base class, since you need to know which Enum sub-class you're currently dealing with in the super class.

With PHP 5.3.0 a feature calles late static binding (http://de3.php.net/manual/en/language.oop5.late-static-bindings.php) was implemented, which can be used to retrieve this information. With this, it's now possible to implement such helper functions directly in the base class.

This patch extends `lang.Enum` class to provide the following helper function to retrieve enum values:
- `lang.Enum::getByName()` - will retrieve an enum value by their name
- `lang.Enum::getByOrdinal()` - will retrieve an enum value by their ordinal value
- `lang.Enum::values()` - will return a list of all enum values

Since it requires PHP >=5.3.0, this pull request will also increase the XP framework requirements for PHP.
