### PR TITLE
Support options for unittest listeners

### DIFF
--- a/core/src/test/php/net/xp_framework/unittest/tests/UnittestRunnerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/tests/UnittestRunnerTest.class.php
@@ -103,7 +103,7 @@
     }
 
     /**
-     * Test -o parameter
+     * Test -l parameter with all arguments required
      *
      */
     #[@test]
@@ -111,6 +111,57 @@
       $return= $this->runner->run(array('-l', 'xp.unittest.DefaultListener', '-'));
       $this->assertEquals(1, $return);
       $this->assertOnStream($this->err, '*** No tests specified');
+    }
+
+    /**
+     * Test -o parameter with missing name and value
+     *
+     */
+    #[@test]
+    public function optionArgMissingNameAndValue() {
+      $return= $this->runner->run(array('-o'));
+      $this->assertEquals(1, $return);
+      $this->assertOnStream($this->err, '*** Option -o requires an argument');
+    }
+
+    /**
+     * Test -o parameter with missing name
+     *
+     */
+    #[@test]
+    public function optionArgMissingValue() {
+      $return= $this->runner->run(array('-o', 'name'));
+      $this->assertEquals(1, $return);
+      $this->assertOnStream($this->err, '*** Option -o requires an argument');
+    }
+
+    /**
+     * Test -o parameter with invalid option
+     *
+     */
+    #[@test]
+    public function optionArgInvalid() {
+      $return= $this->runner->run(array('-o', 'invalid', 'value'));
+      $this->assertEquals(1, $return);
+      $this->assertOnStream($this->err, '*** Unsupported option "invalid" for TestListener');
+    }
+
+    /**
+     * Test -o parameter setting options
+     *
+     */
+    #[@test]
+    public function optionArg() {
+      ClassLoader::getDefault()->defineClass('OptionableTestListener', 'xp.unittest.DefaultListener', array(), '{
+        static $options= array();
+        public function setOption($value) { self::$options[__FUNCTION__]= $value; }
+        public function setVerbose($value) { self::$options[__FUNCTION__]= $value; }
+        public static function options() { return self::$options; }
+      }');
+      $return= $this->runner->run(array('-l', 'OptionableTestListener', '-', '-o', 'option', 'value', '-o', 'verbose', 'on'));
+      $this->assertEquals(1, $return);
+      $this->assertOnStream($this->err, '*** No tests specified');
+      $this->assertEquals(array('setOption' => 'value', 'setVerbose' => 'on'), OptionableTestListener::options());
     }
 
     /**

--- a/tools/src/main/php/xp/unittest/Runner.class.php
+++ b/tools/src/main/php/xp/unittest/Runner.class.php
@@ -41,6 +41,8 @@
    *     multiple times)</li>
    *   <li>-l {listener.class.Name} {output}, where output is either "-"
    *     for console output or a file name</li>
+   *   <li>-o {name} {value}: Set option for last added listener (may be
+   *     used multiple times)
    *   <li>--color={mode} : Enable / disable color; mode can be one of
    *     . "on" - activate color mode
    *     . "off" - disable color mode
@@ -192,7 +194,16 @@
           } else if ('-l' == $args[$i]) {
             $class= XPClass::forName($this->arg($args, ++$i, 'l'));
             $output= $this->streamWriter($this->arg($args, ++$i, 'l'));
-            $suite->addListener($class->newInstance($output));
+            $listener= $suite->addListener($class->newInstance($output));
+          } else if ('-o' == $args[$i]) {
+            $name= $this->arg($args, ++$i, 'o');
+            $value= $this->arg($args, ++$i, 'o');
+            $method= 'set'.ucfirst($name);
+            if ($listener->getClass()->hasMethod($method)) {
+              $listener->getClass()->getMethod($method)->invoke($listener, array($value));
+            } else {
+              throw new IllegalArgumentException('Unsupported option "'.$name.'" for '.$listener->getClassName());
+            }
           } else if ('-?' == $args[$i]) {
             return $this->usage();
           } else if ('-a' == $args[$i]) {


### PR DESCRIPTION
Currently it's possible to specify multiple listeners when invoking the `unittest` command by using the `-l <listener> <output>` option, which is okay for the existing listeners.

But writing more complex listeners you may need to specify some options to configure the listener. This patch introduces a new option which can be used to pass options to the listener.
## The new argument

The `unittest` command accepts the `-l <listener> <output>` options which can be used to add a given listener to the test suite and configure them to use the given output. Additionally to this, it will be possible to specify more options for the listener by using the new `-o <key> <value>` option, which can be specified multiple times and which add the options to the last added listener.

For example it will be possible to run the following command:
`unittest -l xp.unittest.MailListener - -o mailTo user@host.com -o subject Unittest-Report`

This will ...
- add the `xp.unittest.MailListener` (does not exist, is just and example)
- write a report to STDOUT (the first agrument after the listener class - which is default behaviour of -l option)
- set the `mailTo` option
- set the `subject` option
## How does it work

When specifying a listener option, a method is invoked which will get the option value. The method is build by using the option name `ucfirst()`'ed prefixed with "set".

In the example above, the `MailListener` would look like this:

``` php
class MailListener extends Object implements TestListener {

  public function setMailTo($target) {
    $this->mailTo= $target;
  }

  public function setSubject($text) {
    $this->subject= $text;
  }
}
```
