### PR TITLE
Change ArrayType and MapType constructors to accept component types

### DIFF
--- a/core/src/main/php/lang/ArrayType.class.php
+++ b/core/src/main/php/lang/ArrayType.class.php
@@ -9,11 +9,23 @@
   /**
    * Represents array types
    *
-   * @see      xp://lang.Type
-   * @test     xp://net.xp_framework.unittest.core.ArrayTypeTest
-   * @purpose  Type implementation
+   * @see   xp://lang.Type
+   * @test  xp://net.xp_framework.unittest.core.ArrayTypeTest
    */
   class ArrayType extends Type {
+
+    /**
+     * Creates a new array type instance
+     *
+     * @param  var component
+     */
+    public function __construct($component) {
+      if ($component instanceof Type) {
+        parent::__construct($component->getName().'[]');
+      } else {
+        parent::__construct($component.'[]');
+      }
+    }
   
     /**
      * Gets this array's component type
@@ -32,9 +44,11 @@
      * @throws  lang.IllegalArgumentException if the given name does not correspond to a primitive
      */
     public static function forName($name) {
-      if (!strstr($name, '[')) throw new IllegalArgumentException('Not an array: '.$name);
+      if ('[]' !== substr($name, -2)) {
+        throw new IllegalArgumentException('Not an array: '.$name);
+      }
       
-      return new self($name);
+      return new self(substr($name, 0, -2));
     }
 
     /**

--- a/core/src/main/php/lang/MapType.class.php
+++ b/core/src/main/php/lang/MapType.class.php
@@ -9,12 +9,24 @@
   /**
    * Represents map types
    *
-   * @see      xp://lang.Type
-   * @test     xp://net.xp_framework.unittest.core.MapTypeTest
-   * @purpose  Type implementation
+   * @see   xp://lang.Type
+   * @test  xp://net.xp_framework.unittest.core.MapTypeTest
    */
   class MapType extends Type {
-  
+
+    /**
+     * Creates a new array type instance
+     *
+     * @param  var component
+     */
+    public function __construct($component) {
+      if ($component instanceof Type) {
+        parent::__construct('[:'.$component->getName().']');
+      } else {
+        parent::__construct('[:'.$component.']');
+      }
+    }
+
     /**
      * Gets this array's component type
      *
@@ -32,9 +44,11 @@
      * @throws  lang.IllegalArgumentException if the given name does not correspond to a primitive
      */
     public static function forName($name) {
-      if ('[:' !== substr($name, 0, 2)) throw new IllegalArgumentException('Not a map: '.$name);
+      if ('[:' !== substr($name, 0, 2)) {
+        throw new IllegalArgumentException('Not a map: '.$name);
+      }
       
-      return new self($name);
+      return new self(substr($name, 2, -1));
     }
 
     /**

--- a/core/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/ArrayTypeTest.class.php
@@ -35,6 +35,24 @@
     }
 
     /**
+     * Test ArrayType constructor
+     *
+     */
+    #[@test]
+    public function newArrayTypeWithString() {
+      $this->assertEquals(ArrayType::forName('int[]'), new ArrayType('int'));
+    }
+
+    /**
+     * Test ArrayType constructor
+     *
+     */
+    #[@test]
+    public function newArrayTypeWithTypeInstance() {
+      $this->assertEquals(ArrayType::forName('int[]'), new ArrayType(Primitive::$INT));
+    }
+
+    /**
      * Test componentType() method
      *
      */

--- a/core/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/MapTypeTest.class.php
@@ -44,6 +44,24 @@
     }
 
     /**
+     * Test MapType constructor
+     *
+     */
+    #[@test]
+    public function newMapTypeWithString() {
+      $this->assertEquals(MapType::forName('[:int]'), new MapType('int'));
+    }
+
+    /**
+     * Test MapType constructor
+     *
+     */
+    #[@test]
+    public function newMapTypeWithTypeInstance() {
+      $this->assertEquals(MapType::forName('[:int]'), new MapType(Primitive::$INT));
+    }
+
+    /**
      * Test componentType() method
      *
      */


### PR DESCRIPTION
This pull request adds constructors to the `lang.ArrayType` and `lang.MapType` classes which accept the component types.
## Examples

``` php
<?php
  $t= new ArrayType('int');                         // int[]
  $t= new ArrayType(Primitive::$STRING);            // string[]

  $t= new MapType(XPClass::forName('util.Date'));   // [:util.Date]
  $t= new MapType('bool[]');                        // [:bool[]]
?>
```

To use the fully qualified type names, the static `forName()` method continues to exist and work as before on both types - e.g. `ArrayType::forName('int[]')` and `MapType::forName('[:var]')`.
## Usefulness

This is useful if we're working with type instances.

``` php
<?php
  // Before
  public function arrayTypeOf(Type $t) {
    return ArrayType::forName($t->getName().'[]');
  }

  // After
  public function arrayTypeOf(Type $t) {
    return new ArrayType($t);
  }
?>
```

_(same for map types)_
## Note

This includes a BC break for anyone having constructed these instances directly via `new` and not via `Type::forName()`, `ArrayType::forName()` or `MapType::forName()` respectively. The constructor was never advertised as working in this way or another, but rather just existed due to inheritance from `lang.Type`.
