### PR TITLE
 Fix encoding of associative array with modified pointer position

### DIFF
--- a/core/src/main/php/webservices/json/JsonDecoder.class.php
+++ b/core/src/main/php/webservices/json/JsonDecoder.class.php
@@ -199,6 +199,9 @@
             $stream->write(' ]');
             return TRUE;
           } else {
+            // Reset array internal pointer
+            reset($data);
+
             $stream->write('{ ');
 
             $value= each($data);

--- a/core/src/test/php/net/xp_framework/unittest/json/JsonEncodingTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/json/JsonEncodingTest.class.php
@@ -505,5 +505,20 @@
         $this->encode(new Date('2009-05-18 01:02:03'))
       );
     }
+
+    /**
+     * Test encode associative array with modified pointer position
+     *
+     */
+    #[@test]
+    public function encodeAssociativeArrayWithModifiedPointerPosition() {
+      $values= array("10" => "first", "15"=>"second", "22"=>"third");
+      next($values);
+
+      $this->assertEquals(
+        '{ "10" : "first" , "15" : "second" , "22" : "third" }',
+        $this->encode($values)
+      );
+    }
   }
 ?>


### PR DESCRIPTION
Hello,

This pull request fixes the JSON serialization when the data is an associative array and his internal pointer was modified (different from the starting position).

The unittest is self explanatory.

Regards,
Andrei
