### PR TITLE
Drop dependency to scriptlet.HttpSession in util.semaphore

### DIFF
--- a/core/src/main/php/util/semaphore/Semaphore.class.php
+++ b/core/src/main/php/util/semaphore/Semaphore.class.php
@@ -7,8 +7,8 @@
   /**
    * Semaphore class
    *
-   * @see      http://
    * @purpose  Semaphore to serialize request
+   * @deprecated
    */
   class Semaphore extends Object {
     public

--- a/core/src/main/php/util/semaphore/SessionSemaphore.class.php
+++ b/core/src/main/php/util/semaphore/SessionSemaphore.class.php
@@ -6,7 +6,6 @@
 
   uses(
     'util.semaphore.Semaphore',
-    'scriptlet.HttpSession',
     'util.profiling.Timer'
   );
 
@@ -29,6 +28,7 @@
    *
    * @ext      session
    * @purpose  Wrap session semaphores
+   * @deprecated
    */
   class SessionSemaphore extends Semaphore {
 


### PR DESCRIPTION
Remove inter-package dependency; at the same time declare `util.semaphore` package as deprecated - it's an unused feature.

See xp-framework/rfc#262
