### PR TITLE
bc fix for possible old usage of headers in restclient that now fails

### DIFF
--- a/core/src/main/php/webservices/rest/RestRequest.class.php
+++ b/core/src/main/php/webservices/rest/RestRequest.class.php
@@ -232,6 +232,8 @@
     public function addHeader($arg, $value= NULL) {
       if ($arg instanceof Header) {
         $h= $arg;
+      } else if ($value instanceof Header) {
+        $h= $value;
       } else {
         $h= new Header($arg, $value);
       }


### PR DESCRIPTION
The pull request #202 introduced a new behavior and renders a previously working solution invalid.

Example found in xp.contrib/jira-api/JiraClientRest2Protocol [line 52/53]:
Now throws an excetion when Header::toString() is called.

``` php
$req= create(new RestRequest())
  ->withHeader('Authorize', new BasicAuthorization($this->url->getUser(), $this->url->getPassword()));
```

I'll change that location to reflect the new behavior and make a pull request, but this does not mean, that there are no more similar implementations.

If you think we should prevent such errors, this pull request preservs bc (looks ugly though).
