### PR TITLE
By default require SSL connections to be encrypted *and* authenticated

### DIFF
--- a/core/src/main/php/peer/SSLSocket.class.php
+++ b/core/src/main/php/peer/SSLSocket.class.php
@@ -30,6 +30,9 @@
     public function __construct($host, $port, $socket= NULL, $version= NULL) {
       parent::__construct($host, $port, $socket);
       $this->_prefix= 'ssl'.($version ? 'v'.$version : '').'://';
+      $this->setVerifyPeer(TRUE);
+      $this->setAllowSelfSigned(FALSE);
+      // TBD: Where to find CA files?
     }
   }
 ?>

--- a/core/src/main/php/peer/TLSSocket.class.php
+++ b/core/src/main/php/peer/TLSSocket.class.php
@@ -24,6 +24,9 @@
     public function __construct($host, $port, $socket= NULL) {
       parent::__construct($host, $port, $socket);
       $this->_prefix= 'tls://';
+      $this->setVerifyPeer(TRUE);
+      $this->setAllowSelfSigned(FALSE);
+      // TBD: Where to find CA files?
     }
   }
 ?>

--- a/core/src/main/php/peer/http/CurlHttpTransport.class.php
+++ b/core/src/main/php/peer/http/CurlHttpTransport.class.php
@@ -26,8 +26,10 @@
       $this->handle= curl_init();
       curl_setopt($this->handle, CURLOPT_HEADER, 1);
       curl_setopt($this->handle, CURLOPT_RETURNTRANSFER, 1); 
-      curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
-      curl_setopt($this->handle, CURLOPT_SSL_VERIFYPEER, 0);
+
+      // Set SSL specific options:
+      curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 2);
+      curl_setopt($this->handle, CURLOPT_SSL_VERIFYPEER, 1);
       if (1 === sscanf($arg, 'v%d', $version)) {
         curl_setopt($this->handle, CURLOPT_SSLVERSION, $version);
       }


### PR DESCRIPTION
If only using encryption MITM attacks are easily possible, so the framework's default should be changed.

However, this pull requests first serves as a discussion playground for this: to verify a peer certificate, one needs to have a list of trusted root CAs. If missing, no peer certificate will be accepted. The list can change over time, though, so bundling it with the framework is not a good option.

It should be best to use the list of CAs from the system, but there is probably no portable way of finding them. Maybe someone has any insights to this.

On cygwin, there's a bundle of certs here:

``` sh
-> % ls /usr/ssl/certs
README.RootCerts  ca-bundle.crt  ca-bundle.trust.crt  demo  expired
```

On gentoo, it is here (another - probably more suitable format):

``` sh
-> % ls -1l /etc/ssl/certs
total 1012
lrwxrwxrwx 1 root root     29 Jun 11 08:49 024dc131.0 -> Microsec_e-Szigno_Root_CA.pem
lrwxrwxrwx 1 root root     50 Jun 11 08:49 039c618a.0 -> TURKTRUST_Certificate_Services_Provider_Root_2.pem
...
```

On debian, it seems to be the same directory & format.
