### PR TITLE
Fix FileNotFoundException message

### DIFF
--- a/core/src/main/php/io/File.class.php
+++ b/core/src/main/php/io/File.class.php
@@ -181,7 +181,7 @@
         0 != strncmp('php://', $this->uri, 6) &&
         (FILE_MODE_READ == $mode) && 
         (!$this->exists())
-      ) throw new FileNotFoundException($this->uri.' not found');
+      ) throw new FileNotFoundException('File "'.$this->uri.'" not found');
       
       $this->_fd= fopen($this->uri, $this->mode);
       if (!$this->_fd) {

--- a/core/src/main/php/io/ZipFile.class.php
+++ b/core/src/main/php/io/ZipFile.class.php
@@ -30,7 +30,7 @@
         ('php://' != substr($this->uri, 0, 6)) &&
         (FILE_MODE_READ == $mode) && 
         (!$this->exists())
-      ) throw new FileNotFoundException($this->uri.' not found');
+      ) throw new FileNotFoundException('File "'.$this->uri.'" not found');
       
       $this->_fd= gzopen($this->uri, $this->mode.$compression);
       if (!$this->_fd) throw new IOException('cannot open '.$this->uri.' mode '.$this->mode);

--- a/core/src/test/php/net/xp_framework/unittest/tests/UnittestRunnerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/tests/UnittestRunnerTest.class.php
@@ -135,7 +135,7 @@
     public function nonExistantProperties() {
       $return= $this->runner->run(array('@@NON-EXISTANT@@.ini'));
       $this->assertEquals(1, $return);
-      $this->assertOnStream($this->err, '*** @@NON-EXISTANT@@.ini not found');
+      $this->assertOnStream($this->err, '*** File "@@NON-EXISTANT@@.ini" not found');
       $this->assertEquals('', $this->out->getBytes());
     }
 


### PR DESCRIPTION
Currently the `io.FileNotFoundException` expect the first parameter to be a file name. In most cases this exception is used in conjunction with a message string and not with a file name.
# Example

In `io.File` this is used:

``` php
new FileNotFoundException($this->uri);
```

In `xml.DomXSLProcessor` this is used:

``` php
new FileNotFoundException($this->_base.$file.' not found');
```
# Changes

This pull request updates the two places where the `io.FileNotFoundException` is used only with a file name and changes this to pass an exception message.

Passing an exception message will also give us more flexibility on describing what the problem really is. In some places this exception is already used with a more descriptive exception message (e.g. when working with streams).
