### PR TITLE
Inspect web configuration

### DIFF
--- a/core/src/main/php/xp/scriptlet/Inspect.class.php
+++ b/core/src/main/php/xp/scriptlet/Inspect.class.php
@@ -21,7 +21,7 @@
     /**
      * Entry point method. Gets passed the following arguments from "xpws -i":
      * <ul>
-     *   <li>#0: The document root - defaults to $CWD/static</li>
+     *   <li>#0: The web root - defaults to $CWD</li>
      *   <li>#1: The server profile - default to "dev"</li>
      *   <li>#2: The server address - default to "localhost:8080"</li>
      * </ul>
@@ -29,11 +29,10 @@
      * @param   string[] args
      */
     public static function main(array $args) {
-      $docroot= realpath(isset($args[0]) ? $args[0] : getcwd().'/static');
-      $webroot= dirname($docroot);
+      $webroot= isset($args[0]) ? realpath($args[0]) : getcwd();
       $profile= isset($args[1]) ? $args[1] : 'dev';
       $address= isset($args[2]) ? $args[2] : 'localhost:8080';
-      Console::writeLine('xpws-', $profile, ' @ ', $address, ', ', $docroot, ' {');
+      Console::writeLine('xpws-', $profile, ' @ ', $address, ', ', $webroot, ' {');
 
       // Dump configured applications
       $conf= new xp·scriptlet·WebConfiguration(new Properties($webroot.'/etc/web.ini'));


### PR DESCRIPTION
This pull request is part 2 of xp-framework/xp-runners#9 and adds the `xp.scriptlet.Inspect` class necessary for the `xpws -i` command line option to work.
