### PR TITLE
Timer::measure(<callable>)

### DIFF
--- a/core/src/main/php/util/profiling/Timer.class.php
+++ b/core/src/main/php/util/profiling/Timer.class.php
@@ -44,16 +44,19 @@
      *
      * @see    http://php.net/manual/en/language.types.callable.php
      * @param  var block a callable
+     * @return self
      * @throws lang.IllegalArgumentException when block is not callable
      */
-    public function measure($block) {
+    public static function measure($block) {
       if (!is_callable($block)) {
         throw new IllegalArgumentException('Cannot call '.xp::stringOf($block));
       }
 
-      $this->start= microtime(TRUE);
+      $self= new self();
+      $self->start= microtime(TRUE);
       $block();
-      $this->stop= microtime(TRUE);
+      $self->stop= microtime(TRUE);
+      return $self;
     }
 
     /**

--- a/core/src/test/php/net/xp_framework/unittest/util/TimerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/util/TimerTest.class.php
@@ -16,23 +16,14 @@
    * @see      xp://util.profiling.Timer
    */
   class TimerTest extends TestCase {
-    protected $fixture= NULL;
     
-    /**
-     * Setup method. Creates the map member
-     *
-     */
-    public function setUp() {
-      $this->fixture= new Timer();
-    }
-        
     /**
      * Tests elapsed time is zero if not started yet
      *
      */
     #[@test]
     public function initiallyZero() {
-      $this->assertEquals(0.0, $this->fixture->elapsedTime());
+      $this->assertEquals(0.0, create(new Timer())->elapsedTime());
     }
 
     /**
@@ -41,10 +32,11 @@
      */
     #[@test]
     public function elapsedTimeGreaterThanZeroUsingStartAndStop() {
-      $this->fixture->start();
+      $fixture= new Timer();
+      $fixture->start();
       usleep(100 * 1000);
-      $this->fixture->stop();
-      $elapsed= $this->fixture->elapsedTime();
+      $fixture->stop();
+      $elapsed= $fixture->elapsedTime();
       $this->assertTrue($elapsed > 0.0, 'Elapsed time should be greater than zero');
     }
 
@@ -54,10 +46,10 @@
      */
     #[@test]
     public function elapsedTimeGreaterThanZeroUsingMeasure() {
-      $this->fixture->measure(function() {
+      $fixture= Timer::measure(function() {
         usleep(100 * 1000);
       });
-      $elapsed= $this->fixture->elapsedTime();
+      $elapsed= $fixture->elapsedTime();
       $this->assertTrue($elapsed > 0.0, 'Elapsed time should be greater than zero');
     }
 
@@ -67,7 +59,7 @@
      */
     #[@test, @expect('lang.IllegalArgumentException')]
     public function notCallable() {
-      $this->fixture->measure('@not-callable@');
+      Timer::measure('@not-callable@');
     }
   }
 ?>


### PR DESCRIPTION
This pull request picks up on [this idea](https://github.com/xp-framework/rfc/issues/265#issuecomment-12752897) in xp-framework/rfc#265 and extends the `util.profiling.Timer` class with the possibility to measure a closure.

Example:

``` php
$timer= new Timer();
$timer->measure(function() {
  // This is where the stuff happens
});
$elapsed= $timer->elapsedTime();
```

_You can also pass anything deemed [callable](http://php.net/manual/en/language.types.callable.php) by PHP_
