### PR TITLE
Change TypeMarshaller::unmarshal() signature

### DIFF
--- a/core/src/main/php/webservices/rest/TypeMarshaller.class.php
+++ b/core/src/main/php/webservices/rest/TypeMarshaller.class.php
@@ -23,9 +23,10 @@
     /**
      * Unmarshals input
      *
+     * @param  lang.Type target
      * @param  var in
      * @return T
      */
-    public function unmarshal($in);
+    public function unmarshal(Type $target, $in);
   }
 ?>

--- a/core/src/main/php/webservices/rest/srv/DefaultExceptionMarshaller.class.php
+++ b/core/src/main/php/webservices/rest/srv/DefaultExceptionMarshaller.class.php
@@ -28,11 +28,12 @@
     /**
      * Unmarshals input
      *
+     * @param  lang.Type target
      * @param  var in
      * @return lang.Throwable
      */
-    public function unmarshal($in) {
-      return $in instanceof Throwable ? $in : new Throwable((string)$in);
+    public function unmarshal(Type $target, $in) {
+      return $in instanceof Throwable ? $in : $target->newInstance((string)$in);
     }
   }
 ?>

--- a/core/src/main/php/webservices/rest/srv/RestContext.class.php
+++ b/core/src/main/php/webservices/rest/srv/RestContext.class.php
@@ -151,7 +151,7 @@
      */
     public function unmarshal(Type $target, $in) {
       foreach ($this->marshallers->keys() as $type) {
-        if ($type->isAssignableFrom($target)) return $this->marshallers[$type]->unmarshal($in);
+        if ($type->isAssignableFrom($target)) return $this->marshallers[$type]->unmarshal($target, $in);
       }
       return $in;
     }

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/srv/RestContextTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/srv/RestContextTest.class.php
@@ -70,14 +70,14 @@
     public function marshal_this_with_typemarshaller() {
       $this->fixture->addMarshaller('unittest.TestCase', newinstance('webservices.rest.TypeMarshaller', array(), '{
         public function marshal($t) {
-          return $t->getClassName()."::".$t->getName();
+          return $t->getName();
         }
-        public function unmarshal($name) {
+        public function unmarshal(Type $target, $name) {
           // Not needed
         }
       }'));
       $this->assertEquals(
-        new Payload($this->getClassName().'::'.$this->getName()),
+        new Payload($this->getName()),
         $this->fixture->marshal(new Payload($this))
       );
     }
@@ -92,14 +92,13 @@
         public function marshal($t) {
           // Not needed
         }
-        public function unmarshal($name) {
-          sscanf($name, "%[^:]::%s", $class, $test);
-          return XPClass::forName($class)->newInstance($test);
+        public function unmarshal(Type $target, $name) {
+          return $target->newInstance($name);
         }
       }'));
       $this->assertEquals(
         $this,
-        $this->fixture->unmarshal($this->getClass(), $this->getClassName().'::'.$this->getName())
+        $this->fixture->unmarshal($this->getClass(), $this->getName())
       );
     }
 
@@ -673,7 +672,7 @@
         public function marshal($t) {
           return "expected ".xp::stringOf($t->expect)." but was ".xp::stringOf($t->actual);
         }
-        public function unmarshal($name) {
+        public function unmarshal(Type $target, $name) {
           // Not needed
         }
       }'));


### PR DESCRIPTION
This pull request changes `webservices.rest.TypeMarshaller::unmarshal()`'s signature from `unmarshal(var $in)` to `unmarshal(Type $target, var $in)`.
...target, var $in).

This way, type marshallers know to which exact type to unmarshal to instead of having to use the base type, and thus makes unmarshallers reusable!
