### PR TITLE
Reflection bugs for abstract methods in generic classes 

### DIFF
--- a/core/src/main/php/lang/XPClass.class.php
+++ b/core/src/main/php/lang/XPClass.class.php
@@ -1094,6 +1094,18 @@
           } else if (3 === $state[0]) {             // Method body
             if (';' === $tokens[$i][0]) {
               // Abstract method
+              if (isset($annotations[0]['generic']['return'])) {
+                $meta[1][$m][DETAIL_RETURNS]= strtr($annotations[0]['generic']['return'], $placeholders);
+              }
+              if (isset($annotations[0]['generic']['params'])) {
+                foreach (explode(',', $annotations[0]['generic']['params']) as $j => $placeholder) {
+                  if ('' !== ($replaced= strtr(ltrim($placeholder), $placeholders))) {
+                    $meta[1][$m][DETAIL_ARGUMENTS][$j]= $replaced;
+                  }
+                }
+              }
+              $annotations= array();
+              unset($meta[1][$m][DETAIL_ANNOTATIONS]['generic']);
               array_shift($state);
             } else if ('{' === $tokens[$i][0]) {
               $braces= 1;
@@ -1137,7 +1149,7 @@
                 }
               }
 
-              $annotations= array();              
+              $annotations= array();
               unset($meta[1][$m][DETAIL_ANNOTATIONS]['generic']);
               continue;
             }

--- a/core/src/test/php/net/xp_framework/unittest/core/generics/DefinitionReflectionTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/generics/DefinitionReflectionTest.class.php
@@ -175,5 +175,22 @@
       $c= $this->getClass();
       $this->fixture->newGenericType(array($c, $c, $c));
     }
+
+
+    /**
+     * Test newGenericType()
+     *
+     */
+    #[@test]
+    public function abstractMethod() {
+      $abstractMethod= XPClass::forName('net.xp_framework.unittest.core.generics.ArrayFilter')
+        ->newGenericType(array($this->fixture))
+        ->getMethod('accept')
+      ;
+      $this->assertEquals(
+        $this->fixture,
+        $abstractMethod->getParameter(0)->getType()
+      );
+    }
   }
 ?>


### PR DESCRIPTION
This pull request fixes type parameters for abstract methods not being replaced correctly. The meta data (which is used by reflection) contained the placeholders

``` php
[
  DETAIL_ARGUMENTS => array('K'),
  DETAIL_RETURN => 'V'
]
```

...whereas it should have contained the generic arguments' type names:
### Works as expected:

``` php
<?php
  #[@generic(self= 'T')]
  class Test extends Object {
    #[@generic(params= 'T')]
    public function verify($t) { }
  }
?>
```

``` sh
$ xp -w 'XPClass::forName("Test")->newGenericType(array(Primitive::$INT))->getMethod("verify")->getParameters()'
[
  0 => lang.reflect.Parameter<lang.Primitive<int> t>
]
```

:ok:
### Shows the problem with parameters

``` php
<?php
  #[@generic(self= 'T')]
  abstract class Test extends Object {
    #[@generic(params= 'T')]
    public abstract function verify($t);
  }
?>
```

``` sh
$ xp -w 'XPClass::forName("Test")->newGenericType(array(Primitive::$INT))->getMethod("verify")->getParameters()'
[
  0 => lang.reflect.Parameter<lang.Type<var> t>
]
```

:x:  - _expecting `lang.Primitive<int> t`_
### Shows the problem with return types

``` php
<?php
  #[@generic(self= 'T')]
  abstract class Test extends Object {
    #[@generic(return= 'T')]
    public abstract function newInstance();
  }
?>
```

``` sh
$ xp -w 'XPClass::forName("Test")->newGenericType(array(Primitive::$INT))->getMethod("newInstance")->getReturnType()'
lang.Type<void>
```

:x: - _expecting `lang.Primitive<int>`_
