### PR TITLE
[QA] lang.base.php

### DIFF
--- a/core/tools/lang.base.php
+++ b/core/tools/lang.base.php
@@ -205,7 +205,7 @@
     }
     // }}}
     
-    // {{{ proto static void sapi(string* sapis)
+    // {{{ proto deprecated void sapi(string* sapis)
     //     Sets an SAPI
     static function sapi() {
       foreach ($a= func_get_args() as $name) {
@@ -226,7 +226,7 @@
     }
     // }}}
     
-    // {{{ proto static var registry(var args*)
+    // {{{ proto var registry(var args*)
     //     Stores static data
     static function registry() {
       switch (func_num_args()) {


### PR DESCRIPTION
This pull request works on `lang.base.php` and:
- Unifies inline documentation
- Marks "null" and "xarloader" classes as final as documented
- Uses uniqid() instead of microtime for BC generics
- Uses identity comparison in various places instead of equality

The result is a "cleaner look".
