### PR TITLE
String::endsWith() and String::startsWith() performance

### DIFF
--- a/core/src/main/php/lang/types/String.class.php
+++ b/core/src/main/php/lang/types/String.class.php
@@ -266,7 +266,8 @@
      * @return  bool
      */
     public function startsWith($arg) {
-      return 0 == $this->indexOf($arg);
+      $bytes= $this->asIntern($arg);
+      return 0 === strncmp($this->buffer, $bytes, strlen($bytes));
     }
 
     /**


### PR DESCRIPTION
Motivated by @pdietz in [this discussion](https://github.com/xp-framework/xp-framework/pull/267#discussion_r3613149) I tested various implementations for these two methods, and have come up with a performance improvement.
