### PR TITLE
Add getter for the exception mappers in RestContext

### DIFF
--- a/core/src/main/php/webservices/rest/srv/RestContext.class.php
+++ b/core/src/main/php/webservices/rest/srv/RestContext.class.php
@@ -65,7 +65,7 @@
      * @param  var type either a full qualified class name or an XPClass instance
      * @return  webservices.rest.srv.ExceptionMapper 
      */
-    public function addExceptionMapping($type) {
+    public function getExceptionMapping($type) {
       return $this->mappers[$type instanceof XPClass ? $type : XPClass::forName($type)];
     }
 


### PR DESCRIPTION
There is no possibility to check whether an exception is being mapped or not, except for actually mapping the exception to a Response. I think we should expose this information.

The current use case we are having is a custom Exception<i>Marshaller</i> which is supposed to generate output as follows

```
{
  "status": 404, 
  "type": "NOT FOUND", 
  "message": "These aren't the droids you are looking for", 
  "more_info" : "move along" 
}
```

As you see, the marshaller needs the status code information which is only known by the mapper and not passed to the marshaller. It cannot simply try to map the exception as it would get into recursion issues (mapping implies marshalling). The mappers are rendered useless as I would need to remapp all exceptions in the marshaller.

With this pull request it can just pull the mapping info from the context.
