### PR TITLE
RestContext getters

### DIFF
--- a/core/src/main/php/webservices/rest/srv/RestContext.class.php
+++ b/core/src/main/php/webservices/rest/srv/RestContext.class.php
@@ -98,6 +98,16 @@
     }
 
     /**
+     * Adds a type marshaller
+     *
+     * @param  var type either a full qualified type name or a type instance
+     * @return webservices.rest.TypeMarshaller The added marshaller
+     */
+    public function getMarshaller($type) {
+      return $this->marshallers[$type instanceof Type ? $type : Type::forName($type)];
+    }
+
+    /**
      * Maps an exception
      *
      * @param  lang.Throwable t

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/srv/RestContextTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/srv/RestContextTest.class.php
@@ -796,5 +796,30 @@
       }');
       $this->assertEquals($marshaller, $this->fixture->addMarshaller('unittest.TestCase', $marshaller));
     }
+
+    /**
+     * Test getMarshaller()
+     */
+    #[@test]
+    public function get_marshaller() {
+      $marshaller= newinstance('webservices.rest.TypeMarshaller', array(), '{
+        public function marshal($t) {
+          return $t->getName();
+        }
+        public function unmarshal(Type $target, $name) {
+          // Not needed
+        }
+      }');
+      $this->fixture->addMarshaller('unittest.TestCase', $marshaller);
+      $this->assertEquals($marshaller, $this->fixture->getMarshaller('unittest.TestCase'));
+    }
+
+    /**
+     * Test getMarshaller()
+     */
+    #[@test]
+    public function get_non_existant_marshaller() {
+      $this->assertNull($this->fixture->getMarshaller('unittest.TestCase'));
+    }
   }
 ?>


### PR DESCRIPTION
This pull request is based on #283 but not only adds a getter for exception mappers but also for for marshallers.

The new methods introduced are:

``` groovy
public ExceptionMapper getExceptionMapping(var $type)
public TypeMarshaller getMarshaller(var $type)
```

It also changes the `add` variants to return the added instance:

``` groovy
public ExceptionMapper addExceptionMapping(var $type, ExceptionMapper $m)
public TypeMarshaller addMarshaller(var $type, TypeMarshaller $m)
```

Both of the above previously had a `void` return type.
