### PR TITLE
Serialize wrapper types

### DIFF
--- a/core/src/main/php/webservices/rest/RestSerializer.class.php
+++ b/core/src/main/php/webservices/rest/RestSerializer.class.php
@@ -38,7 +38,7 @@
     public function convert($data) {
       if ($data instanceof Date) {
         return $data->toString('c');    // ISO 8601, e.g. "2004-02-12T15:19:21+00:00"
-      } else if ($data instanceof String) {
+      } else if ($data instanceof String || $data instanceof Character) {
         return $data->toString();
       } else if ($data instanceof Integer || $data instanceof Long || $data instanceof Short || $data instanceof Byte) {
         return $data->intValue();

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestSerializerConversionTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestSerializerConversionTest.class.php
@@ -73,6 +73,15 @@
      *
      */
     #[@test]
+    public function char_wrapper_object() {
+      $this->assertEquals('A', $this->fixture->convert(new Character('A')));
+    }
+
+    /**
+     * Test a string
+     *
+     */
+    #[@test]
     public function string_wrapper_object_unicode() {
       $this->assertEquals("\334bercoder", $this->fixture->convert(new String("\303\234bercoder", 'utf-8')));
     }


### PR DESCRIPTION
This pull request implements support for the following wrapper types inside `lang.types` on a suggestion by @iigorr :
- [x] lang.types.ArrayList -> array
- [x] class lang.types.Boolean -> bool
- [x] class lang.types.Integer -> int
- [x] class lang.types.Long -> int
- [x] class lang.types.Short -> int
- [x] class lang.types.Byte -> int
- [x] class lang.types.Double -> double
- [x] class lang.types.Float -> double
- [x] class lang.types.Character -> string
- [x] class lang.types.String -> string
