### PR TITLE
Allow anything inside path segments except the forward slash

### DIFF
--- a/core/src/main/php/webservices/rest/srv/AbstractRestRouter.class.php
+++ b/core/src/main/php/webservices/rest/srv/AbstractRestRouter.class.php
@@ -104,7 +104,7 @@
       $path= rtrim($path, '/');
       $matching= $order= array();
       foreach ($this->routes[$verb] as $route) {
-        if (!preg_match($route->getPattern(), $path, $segments)) continue;
+        if (!($segments= $route->appliesTo($path))) continue;
 
         // Check input type if specified by client
         if (NULL !== $type) {

--- a/core/src/main/php/webservices/rest/srv/RestRoute.class.php
+++ b/core/src/main/php/webservices/rest/srv/RestRoute.class.php
@@ -64,9 +64,19 @@
      */
     public function getPattern() {
       static $search= '/\{([\w]*)\}/';
-      static $replace= '(?P<$1>[%\w:\+\-\.]*)';
+      static $replace= '(?P<$1>[^/]+)';
 
       return '#^'.preg_replace($search, $replace, $this->path).'$#';
+    }
+
+    /**
+     * Get segments
+     *
+     * @param  string path
+     * @return [:string] segments
+     */
+    public function appliesTo($path) {
+      return preg_match($this->getPattern(), $path, $segments) ? $segments : NULL;
     }
 
     /**

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/srv/RestRouteTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/srv/RestRouteTest.class.php
@@ -143,7 +143,7 @@
     #[@test]
     public function pattern_with_placeholder() {
       $r= new RestRoute('GET', '/resource/{id}', $this->handler, $this->target, NULL, NULL);
-      $this->assertEquals('#^/resource/(?P<id>[%\w:\+\-\.]*)$#', $r->getPattern());
+      $this->assertEquals('#^/resource/(?P<id>[^/]+)$#', $r->getPattern());
     }
 
     /**
@@ -153,7 +153,7 @@
     #[@test]
     public function pattern_with_two_placeholders() {
       $r= new RestRoute('GET', '/resource/{id}/{sub}', $this->handler, $this->target, NULL, NULL);
-      $this->assertEquals('#^/resource/(?P<id>[%\w:\+\-\.]*)/(?P<sub>[%\w:\+\-\.]*)$#', $r->getPattern());
+      $this->assertEquals('#^/resource/(?P<id>[^/]+)/(?P<sub>[^/]+)$#', $r->getPattern());
     }
 
     /**
@@ -222,6 +222,147 @@
         'webservices.rest.srv.RestRoute(GET /resource/{id}/{sub} -> void net.xp_framework.unittest.webservices.rest.srv.RestRouteTest::fixtureTarget(@$id: path(\'id\'), @$sub: path(\'sub\')))', 
         $r->toString()
       );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_matches_resource_and_subresource() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertEquals(
+        array(0 => '/binford/6100/chainsaw', 'id' => '6100', 1 => '6100', 'name' => 'chainsaw', 2 => 'chainsaw'),
+        $r->appliesTo('/binford/6100/chainsaw')
+      );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_matches_resource_and_subresource_with_star() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertEquals(
+        array(0 => '/binford/61/*', 'id' => '61', 1 => '61', 'name' => '*', 2 => '*'),
+        $r->appliesTo('/binford/61/*')
+      );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_matches_resource_and_subresource_with_dot() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertEquals(
+        array(0 => '/binford/61/.', 'id' => '61', 1 => '61', 'name' => '.', 2 => '.'),
+        $r->appliesTo('/binford/61/.')
+      );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_matches_resource_and_subresource_with_urlencoded() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertEquals(
+        array(0 => '/binford/61/%40', 'id' => '61', 1 => '61', 'name' => '%40', 2 => '%40'),
+        $r->appliesTo('/binford/61/%40')
+      );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_matches_resource_with_dash() {
+      $r= new RestRoute('GET', '/binford/{id}-{name}', NULL, NULL, NULL, NULL);
+      $this->assertEquals(
+        array(0 => '/binford/610-scissors', 'id' => '610', 1 => '610', 'name' => 'scissors', 2 => 'scissors'),
+        $r->appliesTo('/binford/610-scissors')
+      );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_matches_resource_with_prefix() {
+      $r= new RestRoute('GET', '/binford/power{name}', NULL, NULL, NULL, NULL);
+      $this->assertEquals(
+        array(0 => '/binford/powercar', 'name' => 'car', 1 => 'car'),
+        $r->appliesTo('/binford/powercar')
+      );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_matches_resource_with_postfix() {
+      $r= new RestRoute('GET', '/binford/{name}power', NULL, NULL, NULL, NULL);
+      $this->assertEquals(
+        array(0 => '/binford/morepower', 'name' => 'more', 1 => 'more'),
+        $r->appliesTo('/binford/morepower')
+      );
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_does_not_match_empty_path_segment() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertEquals(NULL, $r->appliesTo('/binford//chainsaw'));
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_does_not_match_base() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertNull($r->appliesTo('/binford'));
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_does_not_match_partial() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertNull($r->appliesTo('/binford/6100'));
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_does_not_match_partial_with_trailing_slash() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertNull($r->appliesTo('/binford/6100/'));
+    }
+
+    /**
+     * Test appliesTo()
+     *
+     */
+    #[@test]
+    public function applies_to_does_not_match_partial_with_trailing_slashes() {
+      $r= new RestRoute('GET', '/binford/{id}/{name}', NULL, NULL, NULL, NULL);
+      $this->assertNull($r->appliesTo('/binford/6100//'));
     }
   }
 ?>


### PR DESCRIPTION
This pull request will change the regular expression used for route matching to allow anything inside segments except the forward slash, `/`.

Given the following pattern via `@path` annotation: `/binford/{id}/{name}`, the current implementation behaves as follows:

:ok: Matches /binford/6100/chainsaw 
:ok: Matches /binford/6100/chainsaw/ - _OK, because trailing slashes are stripped_
:ok: Matches /binford/6100/chainsaw+ 
:ok: Matches /binford/6100/chainsaw-
:ok: Matches /binford/6100/chainsaw%40
:ok: Does not match /binford//chainsaw
:ok: Does not match /binford/6100
:ok: Does not match /binford/
:ok: Does not match /
:no_entry: Does not match /binford/6100/chainsaw@
:no_entry: Does not match /binford/6100/chainsaw*
:no_entry: Does not match /binford/6100/chainsaw;motorcycle
:no_entry: Does not match /binford/6100/chainsaw;model=US
:no_entry: Does not match /binford/6100/chainsaw=awesome

The new implementation gives an :ok: for all of the above. Expressions like `/names/{first}-{last}` still match ungreedy.
