### PR TITLE
With

### DIFF
--- a/core/src/test/php/net/xp_framework/unittest/core/WithTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/WithTest.class.php
@@ -1,0 +1,93 @@
+<?php namespace net\xp_framework\unittest\core;
+
+use lang\Object;
+use lang\ClassLoader;
+
+/**
+ * Tests with() functionality
+ */
+class WithTest extends \unittest\TestCase {
+  protected static $closes= null;
+  protected static $raises= null;
+
+  #[@beforeClass]
+  public static function defineCloseableSubclasses() {
+    self::$closes= ClassLoader::defineClass('_WithTest_C0', 'lang.Object', array('lang.Closeable'), '{
+      public $closed= false;
+      public function close() { $this->closed= true; }
+    }');
+    self::$raises= ClassLoader::defineClass('_WithTest_C1', 'lang.Object', array('lang.Closeable'), '{
+      public function close() { throw new IllegalArgumentException("Cannot close"); }
+    }');
+  }
+
+  #[@test]
+  public function backwards_compatible_usage_without_closure() {
+    with ($f= new Object()); {
+      $this->assertInstanceOf('lang.Object', $f);
+    }
+  }
+
+  #[@test]
+  public function new_usage_with_closure() {
+    with (new Object(), function($f) {
+      $this->assertInstanceOf('lang.Object', $f);
+    });
+  }
+
+  #[@test]
+  public function closeable_is_open_inside_block() {
+    with (self::$closes->newInstance(), function($f) {
+      $this->assertFalse($f->closed);
+    });
+  }
+
+  #[@test]
+  public function closeable_is_closed_after_block() {
+    $f= self::$closes->newInstance();
+    with ($f, function() {
+      // NOOP
+    });
+    $this->assertTrue($f->closed);
+  }
+
+  #[@test]
+  public function all_closeables_are_closed_after_block() {
+    $a= self::$closes->newInstance();
+    $b= self::$closes->newInstance();
+    with ($a, $b, function() {
+      // NOOP
+    });
+    $this->assertEquals(array(true, true), array($a->closed, $b->closed));
+  }
+
+  #[@test]
+  public function all_closeables_are_closed_after_exception() {
+    $a= self::$closes->newInstance();
+    $b= self::$closes->newInstance();
+    try {
+      with ($a, $b, function() {
+        throw new \lang\IllegalStateException('Test');
+      });
+      $this->fail('No exception thrown', null, 'lang.IllegalStateException');
+    } catch (\lang\IllegalStateException $expected) {
+      $this->assertEquals(array(true, true), array($a->closed, $b->closed));
+    }
+  }
+
+  #[@test]
+  public function exceptions_from_close_are_ignored() {
+    with (self::$raises->newInstance(), function() {
+      // NOOP
+    });
+  }
+
+  #[@test]
+  public function exceptions_from_close_are_ignored_and_subsequent_closes_executed() {
+    $b= self::$closes->newInstance();
+    with (self::$raises->newInstance(), $b, function() {
+      // NOOP
+    });
+    $this->assertTrue($b->closed);
+  }
+}

--- a/core/tools/lang.base.php
+++ b/core/tools/lang.base.php
@@ -588,9 +588,27 @@
   }
   // }}}
 
-  // {{{ proto void with(expr)
+  // {{{ proto void with(arg..., Closure)
   //     Syntactic sugar. Intentionally empty
   function with() {
+    $args= func_get_args();
+    if (($block= array_pop($args)) instanceof \Closure)  {
+      try {
+        call_user_func_array($block, $args);
+      } catch (\lang\Throwable $e) {
+        // Fall through
+      } ensure($e); {
+        foreach ($args as $arg) {
+          if (!($arg instanceof \lang\Closeable)) continue;
+          try {
+            $arg->close();
+          } catch (\lang\Throwable $ignored) {
+            // 
+          }
+        }
+        if ($e) throw($e);
+      }
+    }
   }
   // }}}
   


### PR DESCRIPTION
This pull request implements parts of xp-framework/rfc#172 and extends the `with` "statement" to work with `lang.Closeable` instances.

``` php
with (new FileReader(__FILE__), new FileWriter('php://stdout'), function($in, $out) {
  $out->write($in->read());
});
```

Both readers are closed at the end of the block regardless of whether an exception is raised.
