### PR TITLE
Stream Server implementation

### DIFF
--- a/core/src/main/php/peer/BSDSocket.class.php
+++ b/core/src/main/php/peer/BSDSocket.class.php
@@ -417,7 +417,7 @@
      * @return  int
      * @throws  peer.SocketException in case of failure
      */
-    public function select(Sockets $s, $timeout= NULL) {
+    public static function select(Sockets $s, $timeout= NULL) {
       if (NULL === $timeout) {
         $tv_sec= $tv_usec= NULL;
       } else {

--- a/core/src/main/php/peer/BSDSocket.class.php
+++ b/core/src/main/php/peer/BSDSocket.class.php
@@ -303,18 +303,7 @@
       }
       return $n;
     }
-        
-    /**
-     * Returns whether there is data that can be read
-     *
-     * @param   float timeout default NULL Timeout value in seconds (e.g. 0.5)
-     * @return  bool there is data that can be read
-     * @throws  peer.SocketException in case of failure
-     */
-    public function canRead($timeout= NULL) {
-      return $this->_select(array($this->_sock), NULL, NULL, $timeout) > 0;
-    }
-    
+
     /**
      * Returns whether eof has been reached
      *
@@ -323,7 +312,7 @@
     public function eof() {
       return $this->_eof;
     }
-    
+
     /**
      * Reading helper
      *
@@ -418,6 +407,45 @@
       }
       
       return $bytesWritten;
+    }
+
+    /**
+     * Select
+     *
+     * @param   peer.Sockets s
+     * @param   float timeout default NULL Timeout value in seconds (e.g. 0.5)
+     * @return  int
+     * @throws  peer.SocketException in case of failure
+     */
+    public function select(Sockets $s, $timeout= NULL) {
+      if (NULL === $timeout) {
+        $tv_sec= $tv_usec= NULL;
+      } else {
+        $tv_sec= (int)floor($timeout);
+        $tv_usec= (int)(($timeout- $tv_sec) * 1000000);
+      }
+
+      do {
+        $socketSelectInterrupted = FALSE;
+        if (FALSE === ($n= socket_select($s->handles[0], $s->handles[1], $s->handles[2], $tv_sec, $tv_usec))) {
+          $l= __LINE__ - 1;
+
+          // If socket_select has been interrupted by a signal, it will return FALSE,
+          // but no actual error occurred - so check for "real" errors before throwing
+          // an exception. If no error has occurred, skip over to the socket_select again.
+          if (0 !== ($error= socket_last_error()) || xp::errorAt(__FILE__, $l)) {
+            socket_clear_error();
+            $e= new SocketException(sprintf('Select failed - #%d: %s', $error, socket_strerror($error)));
+            xp::gc(__FILE__);
+            throw $e;
+          } else {
+            $socketSelectInterrupted = TRUE;
+          }
+        }
+
+      // if socket_select was interrupted by signal, retry socket_select
+      } while ($socketSelectInterrupted);
+      return $n;
     }
   }
 ?>

--- a/core/src/main/php/peer/ServerSocket.class.php
+++ b/core/src/main/php/peer/ServerSocket.class.php
@@ -37,6 +37,17 @@
       if (extension_loaded('sockets')) {
         self::$impl= XPClass::forName('peer.server.BSDServerSocketImpl');
       } else {
+        define('AF_UNIX', 1);
+        define('AF_INET', 2);
+
+        define('SOCK_STREAM', 1);
+        define('SOCK_DGRAM', 2);
+        define('SOCK_RAW', 3);
+        define('SOCK_RDM', 4);
+        define('SOCK_SEQPACKET', 5);
+
+        define('SOL_TCP', 6);
+        define('SOL_UDP', 17);
         self::$impl= XPClass::forName('peer.server.StreamServerSocketImpl');
       }
     }

--- a/core/src/main/php/peer/ServerSocket.class.php
+++ b/core/src/main/php/peer/ServerSocket.class.php
@@ -4,18 +4,16 @@
  * $Id$
  */
 
-  uses('peer.BSDSocket');
+  uses('peer.SocketHandle', 'peer.Sockets');
 
   /**
-   * BSDSocket server implementation
+   * Server socket interface
    *
    * <code>
    *   $s= new ServerSocket('127.0.0.1', 80);
    *   try {
-   *     $s->create();
    *     $s->bind();
-   *     $s->listen();
-   *   } catch(SocketException $e) {
+   *   } catch (SocketException $e) {
    *     $e->printStackTrace();
    *     $s->close();
    *     exit();
@@ -28,17 +26,21 @@
    *   }
    *   $s->close();
    * </code>
-   *
-   * @purpose  Provide an interface to the BSD sockets                    
-   * @see      xp://peer.BSDSocket
-   * @ext      sockets                                                    
    */
-  class ServerSocket extends BSDSocket {
-    public
-      $domain   = 0,
-      $type     = 0,
-      $protocol = 0;
-      
+  class ServerSocket extends Object implements SocketHandle {
+    public $host    = '';
+    public $protocol= 0;
+
+    protected static $impl = null;
+
+    static function __static() {
+      if (extension_loaded('sockets')) {
+        self::$impl= XPClass::forName('peer.server.BSDServerSocketImpl');
+      } else {
+        self::$impl= XPClass::forName('peer.server.StreamServerSocketImpl');
+      }
+    }
+
     /**
      * Constructor
      *
@@ -49,65 +51,13 @@
      * @param   int protocol default SOL_TCP (one of SOL_TCP or SOL_UDP)
      */
     public function __construct($host, $port, $domain= AF_INET, $type= SOCK_STREAM, $protocol= SOL_TCP) {
-      $this->domain= $domain;
-      $this->type= $type;
-      $this->protocol= $protocol;
-      parent::__construct($host, $port);
+      $this->host= $host;
+      $this->port= $port;
+      $this->impl= self::$impl->newInstance($domain, $type, $protocol);
     }
-    
+
     /**
-     * Connect. Overwritten method from BSDSocket that will always throw
-     * an exception because connect() doesn't make sense here!
-     *
-     * @param   float timeout default 2.0
-     * @return  bool success
-     * @throws  lang.IllegalAccessException
-     */
-    public function connect($timeout= 2.0) {
-      throw new IllegalAccessException('Connect cannot be used on a ServerSocket');
-    }
-    
-    /**
-     * Create
-     *
-     * @return  bool success
-     * @throws  peer.SocketException in case of an error
-     */
-    public function create() {
-      if (!is_resource($this->_sock= socket_create($this->domain, $this->type, $this->protocol))) {
-        throw new SocketException(sprintf(
-          'Creating socket failed: %s',
-          $this->getLastError()
-        ));
-      }
-      
-      return TRUE;
-    }
-    
-    /**
-     * Bind
-     *
-     * @return  bool success
-     * @throws  peer.SocketException in case of an error
-     */
-    public function bind($reuse= FALSE) {
-      if (
-        (FALSE === socket_setopt($this->_sock, SOL_SOCKET, SO_REUSEADDR, $reuse)) ||
-        (FALSE === socket_bind($this->_sock, $this->host, $this->port))
-      ) {
-        throw new SocketException(sprintf(
-          'Binding socket to '.$this->host.':'.$this->port.' failed: %s',
-          $this->getLastError()
-        ));
-      }
-      
-      // Update socket host and port
-      socket_getsockname($this->_sock, $this->host, $this->port);
-      return TRUE;
-    }      
-    
-    /**
-     * Listen on this socket
+     * Bind and listen on this socket
      *
      * <quote>
      * A maximum of backlog incoming connections will be queued for processing. 
@@ -117,21 +67,21 @@
      * succeed. 
      * </quote>
      *
+     * @param   bool reuse default FALSE
      * @param   int backlog default 10
      * @return  bool success
      * @throws  peer.SocketException in case of an error
      */
-    public function listen($backlog= 10) {
-      if (FALSE === socket_listen($this->_sock, $backlog)) {
-        throw new SocketException(sprintf(
-          'Listening on socket failed: %s',
-          $this->getLastError()
-        ));
-      }
-      
+    public function bind($reuse= FALSE, $backlog= 10) {
+      $this->impl->bind($this->host, $this->port, $backlog, $reuse);
+
+      // Update socket host and port (given a ":0" port as parameter,
+      // the member variable will now contain the actual port we bound).
+      $this->host= $this->impl->host();
+      $this->port= $this->impl->port();
       return TRUE;
     }
-    
+
     /**
      * Accept connection
      *
@@ -145,27 +95,73 @@
      *
      * Note: If this socket has been made non-blocking, FALSE will be returned.
      *
-     * @return  var a peer.BSDSocket object or FALSE
+     * @return  var a peer.Socket object or FALSE
      * @throws  peer.SocketException in case of an error
      */
     public function accept() {
-      if (0 > ($msgsock= socket_accept($this->_sock))) {
-        throw new SocketException(sprintf(
-          'Accept failed: %s',
-          $this->getLastError()
-        ));
-      }
-      if (!is_resource($msgsock)) return FALSE;
-      
-      // Get peer
-      if (FALSE === socket_getpeername($msgsock, $host, $port)) {
-        throw new SocketException(sprintf(
-          'Cannot get peer: %s',
-          $this->getLastError()
-        ));      
-      }
-      
-      return new BSDSocket($host, $port, $msgsock);
+      return $this->impl->accept();
+    }
+
+    /**
+     * Returns whether this socket is connected
+     *
+     * @return  bool
+     */
+    public function isConnected() {
+      return $this->impl->isConnected();
+    }
+
+    /**
+     * Returns the underlying socket handle
+     *
+     * @return  var
+     */
+    public function getHandle() {
+      return $this->impl->handle();
+    }
+
+    /**
+     * Closes this socket
+     *
+     * @return  void
+     */
+    public function close() {
+      $this->impl->close();
+    }
+
+    /**
+     * Select
+     *
+     * @param   peer.Sockets s
+     * @param   float timeout default NULL Timeout value in seconds (e.g. 0.5)
+     * @return  int
+     * @throws  peer.SocketException in case of failure
+     */
+    public function select(Sockets $s, $timeout= NULL) {
+      return $this->impl->select($s, $timeout);
+    }
+
+    /**
+     * Create
+     *
+     * @deprecated Does not need to be called any longer
+     * @return  bool success
+     * @throws  peer.SocketException in case of an error
+     */
+    public function create() {
+      return TRUE;
+    }
+
+    /**
+     * Listen on this socket
+     *
+     * @deprecated Does not need to be called any longer
+     * @param   int backlog default 10
+     * @return  bool success
+     * @throws  peer.SocketException in case of an error
+     */
+    public function listen($backlog= 10) {
+      return TRUE;
     }
   }
 ?>

--- a/core/src/main/php/peer/ServerSocket.class.php
+++ b/core/src/main/php/peer/ServerSocket.class.php
@@ -60,11 +60,13 @@
      * @param   int domain default AF_INET (one of AF_INET or AF_UNIX)
      * @param   int type default SOCK_STREAM (one of SOCK_STREAM | SOCK_DGRAM | SOCK_RAW | SOCK_SEQPACKET | SOCK_RDM)
      * @param   int protocol default SOL_TCP (one of SOL_TCP or SOL_UDP)
+     * @param   lang.XPClass impl default NULL
      */
-    public function __construct($host, $port, $domain= AF_INET, $type= SOCK_STREAM, $protocol= SOL_TCP) {
+    public function __construct($host, $port, $domain= AF_INET, $type= SOCK_STREAM, $protocol= SOL_TCP, XPClass $impl= NULL) {
       $this->host= $host;
       $this->port= $port;
-      $this->impl= self::$impl->newInstance($domain, $type, $protocol);
+      if (NULL === $impl) $impl= self::$impl;
+      $this->impl= $impl->newInstance($domain, $type, $protocol);
     }
 
     /**

--- a/core/src/main/php/peer/ServerSocket.class.php
+++ b/core/src/main/php/peer/ServerSocket.class.php
@@ -28,8 +28,8 @@
    * </code>
    */
   class ServerSocket extends Object implements SocketHandle {
-    public $host    = '';
-    public $protocol= 0;
+    public $host     = '';
+    public $protocol = 0;
 
     protected static $impl = null;
 

--- a/core/src/main/php/peer/Socket.class.php
+++ b/core/src/main/php/peer/Socket.class.php
@@ -5,6 +5,7 @@
  */
  
   uses(
+    'peer.SocketHandle',
     'peer.ConnectException',
     'peer.SocketTimeoutException',
     'peer.SocketEndpoint',
@@ -21,7 +22,7 @@
    * @see      php://network
    * @purpose  Basic TCP/IP socket
    */
-  class Socket extends Object {
+  class Socket extends Object implements SocketHandle {
     public
       $_eof     = FALSE,
       $host     = '',

--- a/core/src/main/php/peer/Socket.class.php
+++ b/core/src/main/php/peer/Socket.class.php
@@ -10,7 +10,8 @@
     'peer.SocketEndpoint',
     'peer.SocketException',
     'peer.SocketInputStream',
-    'peer.SocketOutputStream'
+    'peer.SocketOutputStream',
+    'peer.Sockets'
   );
   
   /**
@@ -228,37 +229,7 @@
      * @throws  peer.SocketException in case of failure
      */
     public function canRead($timeout= NULL) {
-      if (NULL === $timeout) {
-        $tv_sec= $tv_usec= NULL;
-      } else {
-        $tv_sec= intval(floor($timeout));
-        $tv_usec= intval(($timeout - floor($timeout)) * 1000000);
-      }
-      $r= array($this->_sock); $w= NULL; $e= NULL;
-      $n= stream_select($r, $w, $e, $tv_sec, $tv_usec);
-      $l= __LINE__ -1;
-      
-      // Implementation vagaries:
-      // * For Windows, when using the VC9 binatries, get rid of "Invalid CRT 
-      //   parameters detected" warning which is no error, see PHP bug #49948
-      // * On Un*x OS flavors, when select() raises a warning, this *is* an 
-      //   error (regardless of the return value)
-      if (isset(xp::$errors[__FILE__])) {
-        if (isset(xp::$errors[__FILE__][$l]['Invalid CRT parameters detected'])) {
-          xp::gc(__FILE__);
-        } else {
-          $n= FALSE;
-        }
-      }
-      
-      // OK, real error here now.
-      if (FALSE === $n || NULL === $n) {
-        $e= new SocketException('Select('.$this->_sock.', '.$tv_sec.', '.$tv_usec.')= failed: '.$this->getLastError());
-        xp::gc(__FILE__);
-        throw $e;
-      }
-      
-      return $n > 0 ? TRUE : !empty($r);
+      return $this->select(new Sockets(array($this)), $timeout) > 0;
     }
 
     /**
@@ -396,7 +367,48 @@
     public function getOutputStream() {
       return new SocketOutputStream($this);
     }
-    
+
+    /**
+     * Select
+     *
+     * @param   peer.Sockets s
+     * @param   float timeout default NULL Timeout value in seconds (e.g. 0.5)
+     * @return  int
+     * @throws  peer.SocketException in case of failure
+     */
+    public function select(Sockets $s, $timeout= NULL) {
+      if (NULL === $timeout) {
+        $tv_sec= $tv_usec= NULL;
+      } else {
+        $tv_sec= intval(floor($timeout));
+        $tv_usec= intval(($timeout - floor($timeout)) * 1000000);
+      }
+      $n= stream_select($s->handles[0], $s->handles[1], $s->handles[2], $tv_sec, $tv_usec);
+      $l= __LINE__ -1;
+
+      // Implementation vagaries:
+      // * For Windows, when using the VC9 binatries, get rid of "Invalid CRT 
+      //   parameters detected" warning which is no error, see PHP bug #49948
+      // * On Un*x OS flavors, when select() raises a warning, this *is* an 
+      //   error (regardless of the return value)
+      if (isset(xp::$errors[__FILE__])) {
+        if (isset(xp::$errors[__FILE__][$l]['Invalid CRT parameters detected'])) {
+          xp::gc(__FILE__);
+        } else {
+          $n= FALSE;
+        }
+      }
+
+      // OK, real error here now.
+      if (FALSE === $n || NULL === $n) {
+        $e= new SocketException('Select('.$s->toString().', '.$tv_sec.', '.$tv_usec.')= failed: '.$this->getLastError());
+        xp::gc(__FILE__);
+        throw $e;
+      }
+
+      return $n > 0 ? $n : sizeof($s->handles[0]) + sizeof($s->handles[1]) + sizeof($s->handles[2]);
+    }
+
     /**
      * Destructor
      *

--- a/core/src/main/php/peer/Socket.class.php
+++ b/core/src/main/php/peer/Socket.class.php
@@ -377,7 +377,7 @@
      * @return  int
      * @throws  peer.SocketException in case of failure
      */
-    public function select(Sockets $s, $timeout= NULL) {
+    public static function select(Sockets $s, $timeout= NULL) {
       if (NULL === $timeout) {
         $tv_sec= $tv_usec= NULL;
       } else {
@@ -402,7 +402,7 @@
 
       // OK, real error here now.
       if (FALSE === $n || NULL === $n) {
-        $e= new SocketException('Select('.$s->toString().', '.$tv_sec.', '.$tv_usec.')= failed: '.$this->getLastError());
+        $e= new SocketException('Select('.$s->toString().', '.$tv_sec.', '.$tv_usec.')= failed');
         xp::gc(__FILE__);
         throw $e;
       }

--- a/core/src/main/php/peer/SocketHandle.class.php
+++ b/core/src/main/php/peer/SocketHandle.class.php
@@ -1,0 +1,22 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$ 
+ */
+
+  uses('lang.Closeable');
+
+  /**
+   * The socket handle interface
+   */
+  interface SocketHandle extends Closeable {
+
+    /**
+     * Returns the underlying socket handle
+     *
+     * @return  var
+     */
+    public function getHandle();
+
+  }
+?>

--- a/core/src/main/php/peer/Sockets.class.php
+++ b/core/src/main/php/peer/Sockets.class.php
@@ -4,6 +4,8 @@
  * $Id$
  */
 
+  uses('peer.SocketHandle');
+
   /**
    * Instances of this Sockets class hold the read, write and except
    * arrays of Socket instances necessary for passing to `select`.
@@ -19,9 +21,9 @@
     /**
      * Creates a new instances
      *
-     * @param  var read either an array of sockets, or NULL
-     * @param  var write either an array of sockets, or NULL
-     * @param  var except either an array of sockets, or NULL
+     * @param  var read either an array of peer.SocketHandles, or NULL
+     * @param  var write either an array of peer.SocketHandles, or NULL
+     * @param  var except either an array of peer.SocketHandles, or NULL
      */
     public function __construct($read= NULL, $write= NULL, $except= NULL) {
       $this->setSockets(0, $read);
@@ -33,7 +35,7 @@
      * Helper: Set handles
      *
      * @param  int n
-     * @param  var arg either an array of sockets, or NULL
+     * @param  var arg either an array of peer.SocketHandles, or NULL
      */
     protected function setSockets($n, $arg) {
       if (NULL === $arg) {
@@ -41,7 +43,7 @@
       } else {
         $this->handles[$n]= array();
         foreach ($arg as $sock) {
-          $handle= cast($sock, 'peer.Socket')->getHandle();
+          $handle= cast($sock, 'peer.SocketHandle')->getHandle();
           $this->handles[$n][]= $handle;
           $this->sockets[(int)$handle]= $sock;
         }
@@ -68,7 +70,7 @@
      * Helper: Get read sockets
      *
      * @param  int n
-     * @return peer.Socket[]
+     * @return peer.SocketHandle[]
      */
     public function read() {
       return $this->getSockets(0);
@@ -78,7 +80,7 @@
      * Helper: Get write sockets
      *
      * @param  int n
-     * @return peer.Socket[]
+     * @return peer.SocketHandle[]
      */
     public function write() {
       return $this->getSockets(1);
@@ -88,7 +90,7 @@
      * Helper: Get except sockets
      *
      * @param  int n
-     * @return peer.Socket[]
+     * @return peer.SocketHandle[]
      */
     public function except() {
       return $this->getSockets(2);

--- a/core/src/main/php/peer/Sockets.class.php
+++ b/core/src/main/php/peer/Sockets.class.php
@@ -1,0 +1,97 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$
+ */
+
+  /**
+   * Instances of this Sockets class hold the read, write and except
+   * arrays of Socket instances necessary for passing to `select`.
+   *
+   * @see   xp://peer.Socket#select
+   * @see   php://socket_select
+   * @see   php://stream_select
+   */
+  class Sockets extends Object {
+    public $handles= array(NULL, NULL, NULL);
+    protected $sockets= array();
+
+    /**
+     * Creates a new instances
+     *
+     * @param  var read either an array of sockets, or NULL
+     * @param  var write either an array of sockets, or NULL
+     * @param  var except either an array of sockets, or NULL
+     */
+    public function __construct($read= NULL, $write= NULL, $except= NULL) {
+      $this->setSockets(0, $read);
+      $this->setSockets(1, $write);
+      $this->setSockets(2, $except);
+    }
+
+    /**
+     * Helper: Set handles
+     *
+     * @param  int n
+     * @param  var arg either an array of sockets, or NULL
+     */
+    protected function setSockets($n, $arg) {
+      if (NULL === $arg) {
+        $this->handles[$n]= NULL;
+      } else {
+        $this->handles[$n]= array();
+        foreach ($arg as $sock) {
+          $handle= cast($sock, 'peer.Socket')->getHandle();
+          $this->handles[$n][]= $handle;
+          $this->sockets[(int)$handle]= $sock;
+        }
+      }
+    }
+
+    /**
+     * Helper: Get sockets
+     *
+     * @param  int n
+     * @return peer.Socket[]
+     */
+    protected function getSockets($n) {
+      $r= array();
+      if (NULL !== $this->handles[$n]) {
+        foreach ($this->handles[$n] as $handle) {
+          $r[]= $this->sockets[(int)$handle];
+        }
+      }
+      return $r;
+    }
+
+    /**
+     * Helper: Get read sockets
+     *
+     * @param  int n
+     * @return peer.Socket[]
+     */
+    public function read() {
+      return $this->getSockets(0);
+    }
+
+    /**
+     * Helper: Get write sockets
+     *
+     * @param  int n
+     * @return peer.Socket[]
+     */
+    public function write() {
+      return $this->getSockets(1);
+    }
+
+    /**
+     * Helper: Get except sockets
+     *
+     * @param  int n
+     * @return peer.Socket[]
+     */
+    public function except() {
+      return $this->getSockets(2);
+    }
+  }
+?>

--- a/core/src/main/php/peer/Sockets.class.php
+++ b/core/src/main/php/peer/Sockets.class.php
@@ -21,9 +21,9 @@
     /**
      * Creates a new instances
      *
-     * @param  var read either an array of peer.SocketHandles, or NULL
-     * @param  var write either an array of peer.SocketHandles, or NULL
-     * @param  var except either an array of peer.SocketHandles, or NULL
+     * @param  peer.SocketHandle[] read or NULL
+     * @param  peer.SocketHandle[] write or NULL
+     * @param  peer.SocketHandle[] except or NULL
      */
     public function __construct($read= NULL, $write= NULL, $except= NULL) {
       $this->setSockets(0, $read);
@@ -32,10 +32,11 @@
     }
 
     /**
-     * Helper: Set handles
+     * Helper: Set sockets
      *
      * @param  int n
-     * @param  var arg either an array of peer.SocketHandles, or NULL
+     * @param  peer.SocketHandle[] except or NULL
+     * @return void
      */
     protected function setSockets($n, $arg) {
       if (NULL === $arg) {
@@ -54,7 +55,7 @@
      * Helper: Get sockets
      *
      * @param  int n
-     * @return peer.Socket[]
+     * @return peer.SocketHandle[]
      */
     protected function getSockets($n) {
       $r= array();

--- a/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
@@ -1,0 +1,130 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$
+ */
+
+  uses('peer.BSDSocket', 'peer.server.ServerSocketImpl');
+
+  /**
+   * BSD server socket implementation
+   *
+   * @ext  sockets
+   * @see  xp://peer.BSDSocket
+   */
+  class BSDServerSocketImpl extends ServerSocketImpl {
+    protected $handle= NULL;
+    protected $host;
+    protected $port;
+
+    public function __construct($domain, $type, $protocol) {
+      if (!is_resource($this->handle= socket_create($domain, $type, $protocol))) {
+        throw new SocketException(sprintf(
+          'Creating socket failed: %s',
+          socket_strerror(socket_last_error())
+        ));
+      }
+    }
+
+    public function bind($host, $port, $backlog= 10, $reuse= TRUE) {
+      if (
+        (FALSE === socket_setopt($this->handle, SOL_SOCKET, SO_REUSEADDR, $reuse)) ||
+        (FALSE === socket_bind($this->handle, $host, $port))
+      ) {
+        throw new SocketException(sprintf(
+          'Binding socket to '.$host.':'.$port.' failed: %s',
+          socket_strerror(socket_last_error($this->handle))
+        ));
+      }
+      
+      socket_getsockname($this->handle, $this->host, $this->port);
+
+      if (FALSE === socket_listen($this->handle, $backlog)) {
+        throw new SocketException(sprintf(
+          'Listening on socket failed: %s',
+          $this->getLastError()
+        ));
+      }
+    }
+
+    /**
+     * Returns the underlying socket host
+     *
+     * @return  string
+     */
+    public function host() {
+      return $this->host;
+    }
+
+    /**
+     * Returns the underlying socket port
+     *
+     * @return  int
+     */
+    public function port() {
+      return $this->port;
+    }
+
+    /**
+     * Returns the underlying socket handle
+     *
+     * @return  var
+     */
+    public function handle() {
+      return $this->handle;
+    }
+
+    /**
+     * Returns whether this socket is connected
+     *
+     * @return  bool
+     */
+    public function isConnected() {
+      return NULL !== $this->handle;
+    }
+
+    public function accept() {
+      if (0 > ($accepted= socket_accept($this->handle))) {
+        throw new SocketException(sprintf(
+          'Accept failed: %s',
+          socket_strerror(socket_last_error($this->handle))
+        ));
+      }
+      if (!is_resource($accepted)) return FALSE;
+      
+      // Get peer
+      if (FALSE === socket_getpeername($accepted, $host, $port)) {
+        throw new SocketException(sprintf(
+          'Cannot get peer: %s',
+          socket_strerror(socket_last_error($accepted))
+        ));      
+      }
+      
+      return new BSDSocket($host, $port, $accepted);
+    }
+
+    /**
+     * Select
+     *
+     * @param   peer.Sockets s
+     * @param   float timeout default NULL Timeout value in seconds (e.g. 0.5)
+     * @return  int
+     * @throws  peer.SocketException in case of failure
+     */
+    public function select(Sockets $s, $timeout= NULL) {
+      var_dump($s);
+      return BSDSocket::select($s, $timeout);
+    }
+
+    public function close() {
+      if ($this->handle) {
+        socket_close($this->handle);
+        $this->handle= NULL;
+      }
+    }
+
+    public function __destruct() {
+      $this->close();
+    }
+  }
+?>

--- a/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
@@ -13,9 +13,6 @@
    * @see  xp://peer.BSDSocket
    */
   class BSDServerSocketImpl extends ServerSocketImpl {
-    protected $handle= NULL;
-    protected $host;
-    protected $port;
 
     /**
      * Constructor

--- a/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
@@ -41,10 +41,10 @@
     public function bind($address, $port= 0, $backlog= 10, $reuse= TRUE) {
       if (
         (FALSE === socket_setopt($this->handle, SOL_SOCKET, SO_REUSEADDR, $reuse)) ||
-        (FALSE === socket_bind($this->handle, $host, $port))
+        (FALSE === socket_bind($this->handle, $address, $port))
       ) {
         throw new SocketException(sprintf(
-          'Binding socket to '.$host.':'.$port.' failed: %s',
+          'Binding socket to '.$address.':'.$port.' failed: %s',
           socket_strerror(socket_last_error($this->handle))
         ));
       }

--- a/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
@@ -17,6 +17,13 @@
     protected $host;
     protected $port;
 
+    /**
+     * Constructor
+     *
+     * @param   int domain default AF_INET (one of AF_INET or AF_UNIX)
+     * @param   int type default SOCK_STREAM (one of SOCK_STREAM | SOCK_DGRAM | SOCK_RAW | SOCK_SEQPACKET | SOCK_RDM)
+     * @param   int protocol default SOL_TCP (one of SOL_TCP or SOL_UDP)
+     */
     public function __construct($domain, $type, $protocol) {
       if (!is_resource($this->handle= socket_create($domain, $type, $protocol))) {
         throw new SocketException(sprintf(
@@ -26,6 +33,14 @@
       }
     }
 
+    /**
+     * Bind a given host and port, with a given backlog
+     *
+     * @param   string host
+     * @param   int port
+     * @param   int backlog
+     * @param   bool reuse
+     */
     public function bind($host, $port, $backlog= 10, $reuse= TRUE) {
       if (
         (FALSE === socket_setopt($this->handle, SOL_SOCKET, SO_REUSEADDR, $reuse)) ||
@@ -48,41 +63,11 @@
     }
 
     /**
-     * Returns the underlying socket host
+     * Accepts an incoming client connection
      *
-     * @return  string
+     * @return  peer.Socket
+     * @throws  peer.SocketException
      */
-    public function host() {
-      return $this->host;
-    }
-
-    /**
-     * Returns the underlying socket port
-     *
-     * @return  int
-     */
-    public function port() {
-      return $this->port;
-    }
-
-    /**
-     * Returns the underlying socket handle
-     *
-     * @return  var
-     */
-    public function handle() {
-      return $this->handle;
-    }
-
-    /**
-     * Returns whether this socket is connected
-     *
-     * @return  bool
-     */
-    public function isConnected() {
-      return NULL !== $this->handle;
-    }
-
     public function accept() {
       if (0 > ($accepted= socket_accept($this->handle))) {
         throw new SocketException(sprintf(
@@ -112,19 +97,19 @@
      * @throws  peer.SocketException in case of failure
      */
     public function select(Sockets $s, $timeout= NULL) {
-      var_dump($s);
       return BSDSocket::select($s, $timeout);
     }
 
+    /**
+     * Closes underlying socket
+     *
+     * @return  void
+     */
     public function close() {
       if ($this->handle) {
         socket_close($this->handle);
         $this->handle= NULL;
       }
-    }
-
-    public function __destruct() {
-      $this->close();
     }
   }
 ?>

--- a/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/BSDServerSocketImpl.class.php
@@ -31,14 +31,14 @@
     }
 
     /**
-     * Bind a given host and port, with a given backlog
+     * Bind a given address and port, with a given backlog
      *
-     * @param   string host
+     * @param   string address
      * @param   int port
      * @param   int backlog
      * @param   bool reuse
      */
-    public function bind($host, $port, $backlog= 10, $reuse= TRUE) {
+    public function bind($address, $port= 0, $backlog= 10, $reuse= TRUE) {
       if (
         (FALSE === socket_setopt($this->handle, SOL_SOCKET, SO_REUSEADDR, $reuse)) ||
         (FALSE === socket_bind($this->handle, $host, $port))

--- a/core/src/main/php/peer/server/PreforkingServer.class.php
+++ b/core/src/main/php/peer/server/PreforkingServer.class.php
@@ -98,32 +98,7 @@
       
       $requests= 0;
       while (!$this->terminate && $requests < $this->maxrequests) {
-        $read= array($this->socket->getHandle());
-        $null= NULL;
-        $timeout= NULL;
-
-        // Check to see if there are sockets with data on it. In case we can
-        // find some, loop over the returned sockets. In case the select() call
-        // fails, break out of the loop and terminate the server - this really
-        // should not happen!
-        do {
-          $socketSelectInterrupted = FALSE;
-          if (FALSE === socket_select($read, $null, $null, $timeout)) {
-
-            // If socket_select has been interrupted by a signal, it will return FALSE,
-            // but no actual error occurred - so check for "real" errors before throwing
-            // an exception. If no error has occurred, skip over to the socket_select again.
-            if (0 !== socket_last_error($this->socket->_sock)) {
-              throw new SocketException('Call to select() failed');
-            } else {
-              $socketSelectInterrupted = TRUE;
-              if ($this->terminate || $this->restart) return;
-            }
-          }
-        // if socket_select was interrupted by signal, retry socket_select
-        } while ($socketSelectInterrupted);
-
-        $m= $this->socket->accept();
+        $this->socket->canRead(NULL) && $m= $this->socket->accept();
 
         // Sanity check
         if (!($m instanceof Socket)) {

--- a/core/src/main/php/peer/server/Server.class.php
+++ b/core/src/main/php/peer/server/Server.class.php
@@ -44,11 +44,15 @@
     /**
      * Constructor
      *
-     * @param   string addr
+     * @param   var arg either a ServerSocket instance or an address
      * @param   int port
      */
-    public function __construct($addr, $port) {
-      $this->socket= new ServerSocket($addr, $port);
+    public function __construct($arg, $port= NULL) {
+      if ($arg instanceof ServerSocket) {
+        $this->socket= $arg;
+      } else {
+        $this->socket= new ServerSocket($arg, $port);
+      }
     }
     
     /**

--- a/core/src/main/php/peer/server/Server.class.php
+++ b/core/src/main/php/peer/server/Server.class.php
@@ -128,7 +128,6 @@
 
       $null= NULL;
       $handles= $lastAction= array();
-      $accepting= $this->socket->getHandle();
       $this->protocol->initialize();
 
       // Loop
@@ -140,7 +139,7 @@
         // Build array of sockets that we want to check for data. If one of them
         // has disconnected in the meantime, notify the listeners (socket will be
         // already invalid at that time) and remove it from the clients list.
-        $read= array($this->socket->getHandle());
+        $read= array($this->socket);
         $currentTime= time();
         foreach ($handles as $h => $handle) {
           if (!$handle->isConnected()) {
@@ -153,7 +152,7 @@
             unset($handles[$h]);
             unset($lastAction[$h]);
           } else {
-            $read[]= $handle->getHandle();
+            $read[]= $handle;
           }
         }
 
@@ -161,29 +160,15 @@
         // find some, loop over the returned sockets. In case the select() call
         // fails, break out of the loop and terminate the server - this really 
         // should not happen!
-        do {
-          $socketSelectInterrupted = FALSE;
-          if (FALSE === socket_select($read, $null, $null, $timeout)) {
-          
-            // If socket_select has been interrupted by a signal, it will return FALSE,
-            // but no actual error occurred - so check for "real" errors before throwing
-            // an exception. If no error has occurred, skip over to the socket_select again.
-            if (0 !== socket_last_error($this->socket->_sock)) {
-              throw new SocketException('Call to select() failed');
-            } else {
-              $socketSelectInterrupted = TRUE;
-            }
-          }
-        // if socket_select was interrupted by signal, retry socket_select
-        } while ($socketSelectInterrupted);
-
-        foreach ($read as $i => $handle) {
+        $test= new Sockets($read, NULL, NULL);
+        $this->socket->select($test, $timeout);
+        foreach ($test->read() as $socket) {
 
           // If there is data on the server socket, this means we have a new client.
           // In case the accept() call fails, break out of the loop and terminate
           // the server - this really should not happen!
-          if ($handle === $accepting) {
-            if (!($m= $this->socket->accept())) {
+          if ($socket->equals($this->socket)) {
+            if (!($m= $socket->accept())) {
               throw new SocketException('Call to accept() failed');
             }
 
@@ -207,13 +192,13 @@
           // Otherwise, a client is sending data. Let the protocol decide what do
           // do with it. In case of an I/O error, close the client socket and remove 
           // the client from the list.
-          $index= (int)$handle;
+          $index= (int)$socket->getHandle();
           $lastAction[$index]= $currentTime;
           try {
-            $this->protocol->handleData($handles[$index]);
+            $this->protocol->handleData($socket);
           } catch (IOException $e) {
-            $this->protocol->handleError($handles[$index], $e);
-            $handles[$index]->close();
+            $this->protocol->handleError($socket, $e);
+            $socket->close();
             unset($handles[$index]);
             unset($lastAction[$index]);
             continue;
@@ -221,9 +206,9 @@
           
           // Check if we got an EOF from the client - in this file the connection
           // was gracefully closed.
-          if (!$handles[$index]->isConnected() || $handles[$index]->eof()) {
-            $this->protocol->handleDisconnect($handles[$index]);
-            $handles[$index]->close();
+          if (!$socket->isConnected() || $socket->eof()) {
+            $this->protocol->handleDisconnect($socket);
+            $socket->close();
             unset($handles[$index]);
             unset($lastAction[$index]);
           }

--- a/core/src/main/php/peer/server/ServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/ServerSocketImpl.class.php
@@ -18,7 +18,7 @@
     protected $port;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param   int domain default AF_INET (one of AF_INET or AF_UNIX)
      * @param   int type default SOCK_STREAM (one of SOCK_STREAM | SOCK_DGRAM | SOCK_RAW | SOCK_SEQPACKET | SOCK_RDM)

--- a/core/src/main/php/peer/server/ServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/ServerSocketImpl.class.php
@@ -1,0 +1,73 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$
+ */
+
+  uses('lang.Closeable');
+
+  /**
+   * Abstract server socket implementation
+   */
+  abstract class ServerSocketImpl extends Object implements Closeable{
+    protected $handle= NULL;
+    protected $host;
+    protected $port;
+
+    public abstract function __construct($domain, $type, $protocol);
+
+    public abstract function bind($host, $port, $backlog= 10, $reuse= TRUE);
+
+    /**
+     * Returns the underlying socket host
+     *
+     * @return  string
+     */
+    public function host() {
+      return $this->host;
+    }
+
+    /**
+     * Returns the underlying socket port
+     *
+     * @return  int
+     */
+    public function port() {
+      return $this->port;
+    }
+
+    /**
+     * Returns the underlying socket handle
+     *
+     * @return  var
+     */
+    public function handle() {
+      return $this->handle;
+    }
+
+    /**
+     * Returns whether this socket is connected
+     *
+     * @return  bool
+     */
+    public function isConnected() {
+      return NULL !== $this->handle;
+    }
+
+    public abstract function accept();
+
+    /**
+     * Select
+     *
+     * @param   peer.Sockets s
+     * @param   float timeout default NULL Timeout value in seconds (e.g. 0.5)
+     * @return  int
+     * @throws  peer.SocketException in case of failure
+     */
+    public abstract function select(Sockets $s, $timeout= NULL);
+
+    public function __destruct() {
+      $this->close();
+    }
+  }
+?>

--- a/core/src/main/php/peer/server/ServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/ServerSocketImpl.class.php
@@ -8,14 +8,32 @@
 
   /**
    * Abstract server socket implementation
+   *
+   * @see  xp://peer.server.BSDServerSocketImpl
+   * @see  xp://peer.server.StreamServerSocketImpl
    */
-  abstract class ServerSocketImpl extends Object implements Closeable{
+  abstract class ServerSocketImpl extends Object implements Closeable {
     protected $handle= NULL;
     protected $host;
     protected $port;
 
+    /**
+     * Constructor
+     *
+     * @param   int domain default AF_INET (one of AF_INET or AF_UNIX)
+     * @param   int type default SOCK_STREAM (one of SOCK_STREAM | SOCK_DGRAM | SOCK_RAW | SOCK_SEQPACKET | SOCK_RDM)
+     * @param   int protocol default SOL_TCP (one of SOL_TCP or SOL_UDP)
+     */
     public abstract function __construct($domain, $type, $protocol);
 
+    /**
+     * Bind a given host and port, with a given backlog
+     *
+     * @param   string host
+     * @param   int port
+     * @param   int backlog
+     * @param   bool reuse
+     */
     public abstract function bind($host, $port, $backlog= 10, $reuse= TRUE);
 
     /**
@@ -54,6 +72,12 @@
       return NULL !== $this->handle;
     }
 
+    /**
+     * Accepts an incoming client connection
+     *
+     * @return  peer.Socket
+     * @throws  peer.SocketException
+     */
     public abstract function accept();
 
     /**
@@ -66,6 +90,9 @@
      */
     public abstract function select(Sockets $s, $timeout= NULL);
 
+    /**
+     * Destructor. Ensure underlying socket is closed.
+     */
     public function __destruct() {
       $this->close();
     }

--- a/core/src/main/php/peer/server/ServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/ServerSocketImpl.class.php
@@ -27,14 +27,14 @@
     public abstract function __construct($domain, $type, $protocol);
 
     /**
-     * Bind a given host and port, with a given backlog
+     * Bind a given address and port, with a given backlog
      *
-     * @param   string host
+     * @param   string address
      * @param   int port
      * @param   int backlog
      * @param   bool reuse
      */
-    public abstract function bind($host, $port, $backlog= 10, $reuse= TRUE);
+    public abstract function bind($address, $port= 0, $backlog= 10, $reuse= TRUE);
 
     /**
      * Returns the underlying socket host

--- a/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
@@ -20,12 +20,22 @@
      * Constructor
      *
      * @param   int domain default AF_INET (one of AF_INET or AF_UNIX)
-     * @param   int type default SOCK_STREAM (one of SOCK_STREAM | SOCK_DGRAM | SOCK_RAW | SOCK_SEQPACKET | SOCK_RDM)
+     * @param   int type default SOCK_STREAM (one of SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, SOCK_RDM or SOCK_SEQPACKET)
      * @param   int protocol default SOL_TCP (one of SOL_TCP or SOL_UDP)
      */
     public function __construct($domain, $type, $protocol) {
-      // XXX
-      $this->protocol= 'tcp';
+      static $protocols= array(
+        SOL_TCP => 'tcp',
+        SOL_UDP => 'udp'
+      );
+
+      if (AF_INET !== $domain) {
+        raise('lang.MethodNotImplementedException', 'Not implemented: AF_UNIX sockets');
+      }
+      if (!isset($protocols[$protocol])) {
+        throw new IllegalArgumentException('Unknown protocol '.$protocol);
+      }
+      $this->protocol= $protocols[$protocol];
       $this->context= stream_context_create();
     }
 

--- a/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
@@ -1,0 +1,109 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$
+ */
+
+  uses('peer.Socket', 'peer.server.ServerSocketImpl');
+
+  /**
+   * Stream server socket implementation
+   *
+   * @see  xp://peer.Socket
+   */
+  class StreamServerSocketImpl extends ServerSocketImpl {
+    protected $handle= NULL;
+    protected $host;
+    protected $port;
+
+    /**
+     * Constructor
+     *
+     * @param   int domain default AF_INET (one of AF_INET or AF_UNIX)
+     * @param   int type default SOCK_STREAM (one of SOCK_STREAM | SOCK_DGRAM | SOCK_RAW | SOCK_SEQPACKET | SOCK_RDM)
+     * @param   int protocol default SOL_TCP (one of SOL_TCP or SOL_UDP)
+     */
+    public function __construct($domain, $type, $protocol) {
+      // XXX
+      $this->protocol= 'tcp';
+      $this->context= stream_context_create();
+    }
+
+    /**
+     * Bind a given host and port, with a given backlog
+     *
+     * @param   string host
+     * @param   int port
+     * @param   int backlog
+     * @param   bool reuse
+     */
+    public function bind($host, $port, $backlog= 10, $reuse= TRUE) {
+      $sock= sprintf('%s://%s:%d', $this->protocol, $host, $port);
+      $this->handle= stream_socket_server(
+        $sock,
+        $errno,
+        $errstr,
+        STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
+        $this->context
+      );
+      if (0 !== $errno) {
+        throw new SocketException(sprintf(
+          'Binding socket to %s failed: #%d: %s',
+          $sock,
+          $errno,
+          $errstr
+        ));
+      }
+
+      $bound= stream_socket_get_name($this->handle, FALSE);
+      if ('[' === $bound{0}) {
+        sscanf($bound, '[%[0-9a-fA-F:]]:%d', $this->host, $this->port);
+      } else {
+        sscanf($bound, '%[^:]:%d', $this->host, $this->port);
+      }
+    }
+
+    /**
+     * Accepts an incoming client connection
+     *
+     * @return  peer.Socket
+     * @throws  peer.SocketException
+     */
+    public function accept() {
+      $accepted= stream_socket_accept($this->handle, -1, $peer);
+      if (!is_resource($accepted)) return FALSE;
+
+      if ('[' === $peer{0}) {
+        sscanf($peer, '[%[0-9a-fA-F:]]:%d', $host, $port);
+      } else {
+        sscanf($peer, '%[^:]:%d', $host, $port);
+      }
+
+      return new Socket($host, $port, $accepted);
+    }
+
+    /**
+     * Select
+     *
+     * @param   peer.Sockets s
+     * @param   float timeout default NULL Timeout value in seconds (e.g. 0.5)
+     * @return  int
+     * @throws  peer.SocketException in case of failure
+     */
+    public function select(Sockets $s, $timeout= NULL) {
+      return Socket::select($s, $timeout);
+    }
+
+    /**
+     * Closes underlying socket
+     *
+     * @return  void
+     */
+    public function close() {
+      if ($this->handle) {
+        fclose($this->handle);
+        $this->handle= NULL;
+      }
+    }
+  }
+?>

--- a/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
@@ -40,14 +40,14 @@
     }
 
     /**
-     * Bind a given host and port, with a given backlog
+     * Bind a given address and port, with a given backlog
      *
-     * @param   string host
+     * @param   string address
      * @param   int port
      * @param   int backlog
      * @param   bool reuse
      */
-    public function bind($host, $port, $backlog= 10, $reuse= TRUE) {
+    public function bind($address, $port= 0, $backlog= 10, $reuse= TRUE) {
       $sock= sprintf('%s://%s:%d', $this->protocol, $host, $port);
       $this->handle= stream_socket_server(
         $sock,

--- a/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
+++ b/core/src/main/php/peer/server/StreamServerSocketImpl.class.php
@@ -39,6 +39,7 @@
       } else {
         throw new IllegalArgumentException('Unknown domain '.$doman);
       }
+
       $this->context= stream_context_create();
     }
 
@@ -51,7 +52,7 @@
      * @param   bool reuse
      */
     public function bind($address, $port= 0, $backlog= 10, $reuse= TRUE) {
-      $sock= sprintf($this->protocol, $host, $port);
+      $sock= sprintf($this->protocol, $address, $port);
       $this->handle= stream_socket_server(
         $sock,
         $errno,

--- a/core/src/test/config/unittest/peer.ini
+++ b/core/src/test/config/unittest/peer.ini
@@ -21,8 +21,11 @@ class="net.xp_framework.unittest.peer.sockets.SocketTimeoutExceptionTest"
 [header]
 class="net.xp_framework.unittest.peer.HeaderTest"
 
-[server]
-class="net.xp_framework.unittest.peer.server.ServerTest"
+[stream.server]
+class="net.xp_framework.unittest.peer.server.StreamServerTest"
+
+[bsd.server]
+class="net.xp_framework.unittest.peer.server.BSDServerTest"
 
 [accept-handler]
 class="net.xp_framework.unittest.peer.server.AcceptingServerTest"

--- a/core/src/test/php/net/xp_framework/unittest/peer/server/AbstractServerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/server/AbstractServerTest.class.php
@@ -52,15 +52,16 @@ abstract class AbstractServerTest extends TestCase {
    * Starts server in background
    *
    * @param   string protocol
+   * @param   string impl
    */
-  public static function startServerWith($protocol) {
+  public static function startServerWith($protocol, $impl= 'StreamServerSocketImpl') {
 
     // Start server process
     with ($rt= Runtime::getInstance()); {
       self::$serverProcess= $rt->getExecutable()->newInstance(array_merge(
         $rt->startupOptions()->asArguments(),
         array($rt->bootstrapScript('class')),
-        array('net.xp_framework.unittest.peer.server.TestingServer', $protocol)
+        array('net.xp_framework.unittest.peer.server.TestingServer', $protocol, $impl)
       ));
     }
     self::$serverProcess->in->close();

--- a/core/src/test/php/net/xp_framework/unittest/peer/server/BSDServerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/server/BSDServerTest.class.php
@@ -1,0 +1,39 @@
+<?php namespace net\xp_framework\unittest\peer\server;
+
+/**
+ * TestCase for default server protocol
+ *
+ * @see  xp://peer.server.Server
+ */
+#[@action(new \unittest\actions\ExtensionAvailable('sockets'))]
+class BSDServerTest extends AbstractServerTest {
+  
+  /**
+   * Starts server in background
+   */
+  #[@beforeClass]
+  public static function startServer() {
+    parent::startServerWith('net.xp_framework.unittest.peer.server.TestingProtocol', 'BSDServerSocketImpl');
+  }
+
+  #[@test]
+  public function connected() {
+    $this->connect();
+    $this->assertHandled(array('CONNECT'));
+  }
+
+  #[@test]
+  public function disconnected() {
+    $this->connect();
+    $this->conn->close();
+    $this->assertHandled(array('CONNECT', 'DISCONNECT'));
+  }
+
+  #[@test, @ignore('Fragile test, dependant on OS / platform and implementation vagaries')]
+  public function error() {
+    $this->connect();
+    $this->conn->write("SEND\n");
+    $this->conn->close();
+    $this->assertHandled(array('CONNECT', 'ERROR'));
+  }
+}

--- a/core/src/test/php/net/xp_framework/unittest/peer/server/StreamServerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/server/StreamServerTest.class.php
@@ -1,36 +1,26 @@
 <?php namespace net\xp_framework\unittest\peer\server;
 
-
-
 /**
  * TestCase for default server protocol
  *
+ * @see  xp://peer.server.Server
  */
-class ServerTest extends AbstractServerTest {
+class StreamServerTest extends AbstractServerTest {
   
   /**
    * Starts server in background
-   *
    */
   #[@beforeClass]
   public static function startServer() {
-    parent::startServerWith('net.xp_framework.unittest.peer.server.TestingProtocol');
+    parent::startServerWith('net.xp_framework.unittest.peer.server.TestingProtocol', 'StreamServerSocketImpl');
   }
 
-  /**
-   * Test handleConnect() is invoked
-   *
-   */
   #[@test]
   public function connected() {
     $this->connect();
     $this->assertHandled(array('CONNECT'));
   }
 
-  /**
-   * Test handleDisconnect() is invoked
-   *
-   */
   #[@test]
   public function disconnected() {
     $this->connect();
@@ -38,10 +28,6 @@ class ServerTest extends AbstractServerTest {
     $this->assertHandled(array('CONNECT', 'DISCONNECT'));
   }
 
-  /**
-   * Test handleError() is invoked
-   *
-   */
   #[@test, @ignore('Fragile test, dependant on OS / platform and implementation vagaries')]
   public function error() {
     $this->connect();

--- a/core/src/test/php/net/xp_framework/unittest/peer/server/TestingServer.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/server/TestingServer.class.php
@@ -1,6 +1,8 @@
 <?php namespace net\xp_framework\unittest\peer\server;
 
 use util\cmd\Console;
+use lang\reflect\Package;
+use peer\ServerSocket;
 use peer\server\Server;
 use peer\server\ServerProtocol;
 
@@ -26,7 +28,9 @@ class TestingServer extends \lang\Object {
    * @param   string[] args
    */
   public static function main(array $args) {
-    $s= new Server('127.0.0.1', 0);
+    $impl= Package::forName('peer.server')->loadClass($args[1]);
+
+    $s= new Server(new ServerSocket('127.0.0.1', 0, AF_INET, SOCK_STREAM, SOL_TCP, $impl));
     try {
       $s->setProtocol(\lang\XPClass::forName($args[0])->newInstance());
       $s->init();

--- a/core/src/test/php/net/xp_framework/unittest/peer/server/TestingServer.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/server/TestingServer.class.php
@@ -1,11 +1,8 @@
 <?php namespace net\xp_framework\unittest\peer\server;
 
-
-
 use util\cmd\Console;
 use peer\server\Server;
 use peer\server\ServerProtocol;
-
 
 /**
  * Socket server used by ServerTest. 


### PR DESCRIPTION
This pull request removes the hard dependency on `ext/sockets` for creating standalone servers: PHP's stream API has had [an equivalent functionality](http://de3.php.net/manual/de/function.stream-socket-server.php) for quite a while now.

* [x] We'll start by abstracting the `select()` call into the two existing implementations, `peer.Socket` and `peer.BSDSocket`, and changing the `peer.server` implementations to use that.
* [x] After that, we'll extract the implementation of `peer.ServerSocket` into `ServerSocketImpl` classes, and provide one that works with BSD sockets and one with streams
* [x] Next, we'll change the Server API to choose based on availability of ext/sockets whether to use the BSD or the stream based implementation.

The default for servers (given that `ext/sockets` is available) is still to use it. The stream server only comes in when that is not the case.