### PR TITLE
Sybase/MSSQL: Fix for repeated EED messages

### DIFF
--- a/core/src/main/php/rdbms/tds/TdsProtocol.class.php
+++ b/core/src/main/php/rdbms/tds/TdsProtocol.class.php
@@ -409,6 +409,7 @@
      */
     public function connect($user= '', $password= '') {
       $this->stream->connect();
+      $this->messages= array();
       $this->login($user, $password);
       $response= $this->read();
 

--- a/core/src/main/php/rdbms/tds/TdsProtocol.class.php
+++ b/core/src/main/php/rdbms/tds/TdsProtocol.class.php
@@ -465,7 +465,6 @@
      */
     protected function read() {
       $this->done= FALSE;
-      $this->messages= array();
       $type= $this->stream->begin();
 
       // Check for message type

--- a/core/src/main/php/rdbms/tds/TdsProtocolException.class.php
+++ b/core/src/main/php/rdbms/tds/TdsProtocolException.class.php
@@ -29,9 +29,10 @@
      * @param   string server
      * @param   string proc
      * @param   int line
+     * @param   lang.Throwable cause default NULL
      */
-    public function __construct($message, $number= 0, $state= 0, $class= 0, $server= NULL, $proc= NULL, $line= 0) {
-      parent::__construct($message);
+    public function __construct($message, $number= 0, $state= 0, $class= 0, $server= NULL, $proc= NULL, $line= 0, $cause= NULL) {
+      parent::__construct($message, $cause);
       $this->number= $number;
       $this->state= $state;
       $this->class= $class;

--- a/core/src/main/php/rdbms/tds/TdsV5Protocol.class.php
+++ b/core/src/main/php/rdbms/tds/TdsV5Protocol.class.php
@@ -9,6 +9,7 @@
   /**
    * TDS V5 protocol implementation
    *
+   * @see   http://www.sybase.com/content/1013412/tds34.pdf
    * @see   https://github.com/mono/mono/blob/master/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol/Tds50.cs
    */
   class TdsV5Protocol extends TdsProtocol {

--- a/core/src/main/php/rdbms/tds/TdsV5Protocol.class.php
+++ b/core/src/main/php/rdbms/tds/TdsV5Protocol.class.php
@@ -168,7 +168,7 @@
       }
       // DEBUG Console::writeLine($initial ? 'I' : 'E', $type, ' ', $old, ' -> ', $new);
     }
-    
+
     /**
      * Issues a query and returns the results
      *
@@ -236,15 +236,14 @@
           }
           return $fields;
         } else if ("\xFD" === $token || "\xFF" === $token || "\xFE" === $token) {   // DONE
-          $meta= $this->stream->get('vstatus/vcmd/Vrowcount', 8);
-          if ($meta['status'] & 0x0001) {
+          if (-1 === ($rows= $this->handleDone())) {
             $token= $this->stream->getToken();
             continue;
           }
           $this->done= TRUE;
-          return $meta['rowcount'];
+          return $rows;
         } else if ("\xE5" === $token) {   // EED (messages or errors)
-          $this->handleExtendedError();
+          $this->handleEED();
           $token= $this->stream->getToken();
         } else if ("\xE3" === $token) {   // ENVCHANGE, e.g. from "use [db]" queries
           $this->envchange();

--- a/core/src/main/php/rdbms/tds/TdsV5Protocol.class.php
+++ b/core/src/main/php/rdbms/tds/TdsV5Protocol.class.php
@@ -176,6 +176,7 @@
      * @return  var
      */
     public function query($sql) {
+      $this->messages= array();
       $this->stream->write(self::MSG_QUERY, $sql);
       $token= $this->read();
 

--- a/core/src/main/php/rdbms/tds/TdsV7Protocol.class.php
+++ b/core/src/main/php/rdbms/tds/TdsV7Protocol.class.php
@@ -242,15 +242,17 @@
           }
           return $fields;
         } else if ("\xFD" === $token || "\xFF" === $token || "\xFE" === $token) {   // DONE
-          $meta= $this->stream->get('vstatus/vcmd/Vrowcount', 8);
-          if ($meta['status'] & 0x0001) {
+          if (-1 === ($rows= $this->handleDone())) {
             $token= $this->stream->getToken();
             continue;
           }
           $this->done= TRUE;
-          return $meta['rowcount'];
+          return $rows;
         } else if ("\xAB" === $token) {   // INFO
           $this->handleInfo();
+          $token= $this->stream->getToken();
+        } else if ("\xE5" === $token) {   // EED (messages or errors)
+          $this->handleEED();
           $token= $this->stream->getToken();
         } else if ("\xE3" === $token) {   // ENVCHANGE, e.g. from "use [db]" queries
           $this->envchange();

--- a/core/src/main/php/rdbms/tds/TdsV7Protocol.class.php
+++ b/core/src/main/php/rdbms/tds/TdsV7Protocol.class.php
@@ -202,6 +202,7 @@
      * @return  var
      */
     public function query($sql) {
+      $this->messages= array();
       $this->stream->write(self::MSG_QUERY, iconv(xp::ENCODING, 'ucs-2le', $sql));
       $token= $this->read();
 

--- a/core/src/test/php/net/xp_framework/unittest/rdbms/integration/MsSQLIntegrationTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rdbms/integration/MsSQLIntegrationTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\rdbms\integration;
 
+use rdbms\SQLStatementFailedException;
+
 /**
  * MSSQL integration test
  *

--- a/core/src/test/php/net/xp_framework/unittest/rdbms/integration/SybaseIntegrationTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rdbms/integration/SybaseIntegrationTest.class.php
@@ -168,7 +168,7 @@ class SybaseIntegrationTest extends RdbmsIntegrationTest {
     $this->assertEquals(1, $q->next('result'));
   }
 
-  #[@test, @expect(class= 'rdbms.SQLStatementFailedException', withMessage= '/241/')]
+  #[@test, @expect(class= 'rdbms.SQLStatementFailedException', withMessage= '/Truncation/')]
   public function dataTruncationWarning() {
     $conn= $this->db();
     $conn->query('
@@ -178,6 +178,12 @@ class SybaseIntegrationTest extends RdbmsIntegrationTest {
       )',
       $this->tableName()
     );
-    $conn->insert('into %c (cost) values (123.12345)', $this->tableName());
+    $conn->insert('into %c (id, cost) values (1, 123.12345)', $this->tableName());
+  }
+
+  #[@test, @expect('rdbms.SQLStatementFailedException')]
+  public function repeated_extend_errors() {
+    $this->createTable();
+    $this->db()->select('not_the_table_name.field1, not_the_table_name.field2 from %c', $this->tableName());
   }
 }

--- a/core/src/test/php/net/xp_framework/unittest/rdbms/integration/SybaseIntegrationTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rdbms/integration/SybaseIntegrationTest.class.php
@@ -170,7 +170,7 @@ class SybaseIntegrationTest extends RdbmsIntegrationTest {
     $this->assertEquals(1, $q->next('result'));
   }
 
-  #[@test, @expect(class= 'rdbms.SQLStatementFailedException', withMessage= '/Truncation/')]
+  #[@test, @expect('rdbms.SQLStatementFailedException')]
   public function dataTruncationWarning() {
     $conn= $this->db();
     $conn->query('

--- a/core/src/test/php/net/xp_framework/unittest/rdbms/integration/SybaseIntegrationTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/rdbms/integration/SybaseIntegrationTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\xp_framework\unittest\rdbms\integration;
 
+use rdbms\SQLStatementFailedException;
+
 /**
  * Sybase integration test
  *
@@ -181,9 +183,16 @@ class SybaseIntegrationTest extends RdbmsIntegrationTest {
     $conn->insert('into %c (id, cost) values (1, 123.12345)', $this->tableName());
   }
 
-  #[@test, @expect('rdbms.SQLStatementFailedException')]
+  #[@test]
   public function repeated_extend_errors() {
     $this->createTable();
-    $this->db()->select('not_the_table_name.field1, not_the_table_name.field2 from %c', $this->tableName());
+    $conn= $this->db();
+    try {
+      $conn->select('not_the_table_name.field1, not_the_table_name.field2 from %c', $this->tableName());
+      $this->fail('No exception raised', NULL, 'rdbms.SQLStatementFailedException');
+    } catch (SQLStatementFailedException $expected) {
+      // OK
+    }
+    $this->assertEquals(array(0 => array('working' => 1)), $conn->select('1 as working'));
   }
 }


### PR DESCRIPTION
This pull request fixes repeated EED server messages causing error handling to break subsequent queries. An error like this can be provoked by issuing a query as follows:

```sql
select not_the_table_name.field1, not_the_table_name.field2 from table_name
```

This pull request adds an integration test to verify this. If this test is run with the implementation existing on the master branch, the effect can nicely be seen:

```
F unittest.TestError(test= net.xp_framework.unittest.rdbms.integration.SybaseIntegrationTest::repeated_extend_errors, time= 0.027 seconds) {
  Exception rdbms.SQLStatementFailedException (errorcode 0: Unexpected token 0x5F (number 0)) {
    select 1
  }
```