### PR TITLE
Resolving properties

### DIFF
--- a/core/src/main/php/util/PropertyDecorator.class.php
+++ b/core/src/main/php/util/PropertyDecorator.class.php
@@ -1,0 +1,167 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$
+ */
+
+  uses(
+    'lang.Object',
+    'util.PropertyAccess'
+  );
+
+  /**
+   * Abstract property decorator
+   */
+  abstract class PropertyDecorator extends Object implements PropertyAccess {
+
+    protected $properties;
+
+    /**
+     * @param PropertyAccess $decoratedProperties
+     */
+    public function __construct(PropertyAccess $decoratedProperties) {
+      $this->properties= $decoratedProperties;
+    }
+
+    /**
+     * Returns the decorated properties object
+     *
+     * @return PropertyAccess
+     */
+    public function getDecoratedProperties() {
+      return $this->properties;
+    }
+
+    /**
+     * Read array value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   mixed $default default array()
+     * @return  string[]
+     */
+    public function readArray($section, $key, $default= array()) {
+      return $this->properties->readArray($section, $key, $default);
+    }
+
+    /**
+     * Read hash value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   mixed $default default NULL
+     * @return  $util.Hashmap
+     */
+    public function readHash($section, $key, $default= NULL) {
+      return $this->properties->readHash($section, $key, $default);
+    }
+
+    /**
+     * Read bool value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   bool $default default FALSE
+     * @return  bool
+     */
+    public function readBool($section, $key, $default= FALSE) {
+      return $this->properties->readBool($section, $key, $default);
+    }
+
+    /**
+     * Read string value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   mixed $default default NULL
+     * @return  string
+     */
+    public function readString($section, $key, $default= NULL) {
+      return $this->properties->readString($section, $key, $default);
+    }
+
+    /**
+     * Read integer value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   mixed $default default 0
+     * @return  int
+     */
+    public function readInteger($section, $key, $default= 0) {
+      return $this->properties->readInteger($section, $key, $default);
+    }
+
+    /**
+     * Read float value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   mixed $default default array()
+     * @return  double
+     */
+    public function readFloat($section, $key, $default= 0.0) {
+      return $this->properties->readFloat($section, $key, $default);
+    }
+
+    /**
+     * Read section
+     *
+     * @param   string $section
+     * @param   mixed $default default array()
+     * @return  [:string]
+     */
+    public function readSection($section, $default= array()) {
+      return $this->properties->readSection($section, $default);
+    }
+
+    /**
+     * Read range value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   mixed $default default 0.0
+     * @return  int[]
+     */
+    public function readRange($section, $key, $default= array()) {
+      return $this->properties->readRange($section, $key, $default);
+    }
+
+    /**
+     * Test whether a given section exists
+     *
+     * @param   string $section
+     * @return  bool
+     */
+    public function hasSection($section) {
+      return $this->properties->hasSection($section);
+    }
+
+    /**
+     * Retrieve first section name, set internal pointer
+     *
+     * @return  string
+     */
+    public function getFirstSection() {
+      return $this->properties->getFirstSection();
+    }
+
+    /**
+     * Retrieve next section name, NULL if no more sections exist
+     *
+     * @return  string
+     */
+    public function getNextSection() {
+      return $this->properties->getNextSection();
+    }
+
+    /**
+     * Creates a string representation of this property file
+     *
+     * @return  string
+     */
+    public function toString() {
+      return $this->getClassName() . '(' .  $this->properties->toString() . ')';
+    }
+
+  }

--- a/core/src/main/php/util/PropertyManager.class.php
+++ b/core/src/main/php/util/PropertyManager.class.php
@@ -8,7 +8,8 @@
     'util.Properties',
     'util.CompositeProperties',
     'util.RegisteredPropertySource',
-    'util.FilesystemPropertySource'
+    'util.FilesystemPropertySource',
+    'util.ResolvingProperties'
   );
   
   /**
@@ -176,13 +177,13 @@
       }
 
       switch (sizeof($found)) {
-        case 1: return $found[0];
+        case 1: return new ResolvingProperties($found[0]);
         case 0: raise('lang.ElementNotFoundException', sprintf(
           'Cannot find properties "%s" in any of %s',
           $name,
           xp::stringOf(array_values($this->provider))
         ));
-        default: return new CompositeProperties($found);
+        default: return new ResolvingProperties(new CompositeProperties($found));
       }
 	  }
   }

--- a/core/src/main/php/util/ResolvingProperties.class.php
+++ b/core/src/main/php/util/ResolvingProperties.class.php
@@ -1,0 +1,163 @@
+<?php
+/* This class is part of the XP framework
+ *
+ * $Id$
+ */
+  
+  uses(
+    'lang.Object',
+    'lang.ElementNotFoundException',
+    'lang.FormatException',
+    'lang.XPException',
+    'util.PropertyManager',
+    'util.PropertyDecorator'
+  );
+
+  /**
+   * Decorator for util.Properties which allows the usage of special tokens in string values:
+   *
+   * For example
+   * <pre>
+   * [section]
+   * key1=${prop.properties.section.key}
+   * key2=${prop.properties.section.key|default}
+   * key3=${env.envname}
+   * </pre>
+   *
+   * Available tokens:
+   * * env
+   *   Returns the content of an environment variable.
+   * * prop
+   *   Returns the content of another property object
+   *
+   * @see   util.Properties
+   * @test  xp://net.xp_framework.unittest.util.ResolvingPropertiesTest
+   */
+  class ResolvingProperties extends PropertyDecorator  {
+
+    protected $propertyManager;
+
+    /**
+     * @param PropertyAccess $decoratedProperties
+     * @param PropertyManager $propertyManager Allows to inject a specific property manager
+     */
+    public function __construct(
+      PropertyAccess $decoratedProperties,
+      PropertyManager $propertyManager= null
+    ) {
+      $this->properties= $decoratedProperties;
+      $this->propertyManager= $propertyManager ?: PropertyManager::getInstance();
+    }
+
+    /**
+     * Read string value
+     *
+     * @param   string $section
+     * @param   string $key
+     * @param   mixed $default default NULL
+     * @return  string
+     */
+    public function readString($section, $key, $default= NULL) {
+      $ret= $this->properties->readString($section, $key, $default);
+
+      if ($ret != NULL && strpos($ret, '${') !== false) {
+        $ret= preg_replace_callback(
+          '/\$\{([^.}]*)\.([^}|]*)(?:\|([^}]*))?\}/',
+          array($this, 'replaceToken'),
+          $ret
+        );
+      }
+
+      return $ret;
+    }
+
+    /**
+     * Callback function for token replace regex
+     *
+     * @param   string[] $match
+     * @return  string
+     * @throws  lang.FormatException
+     */
+    private function replaceToken($match) {
+      $arguments= $match[2];
+      $default= isset($match[3]) ? $match[3] : NULL;
+      $replacement= '';
+      switch ($match[1]) {
+        case 'prop':
+          $replacement= $this->processPropToken($arguments, $default);
+          break;
+        case 'env':
+          $replacement= $this->processEnvToken($arguments, $default);
+          break;
+        default:
+          throw new FormatException('Unknown placeholder "' . $match[1] . '"');
+      }
+      return $replacement;
+    }
+
+    /**
+     * Processes the "prop" token
+     *
+     * @param   string $arguments
+     * @param   string $default
+     * @return  string
+     * @throws  lang.ElementNotFoundException
+     * @throws  lang.FormatException
+     */
+    private function processPropToken($arguments, $default) {
+      $value= '';
+      $args= explode('.', $arguments);
+      if (count($args) != 3) {
+        throw new FormatException('Invalid arguments "' . $arguments . '"');
+      }
+      if ($this->propertyManager->hasProperties($args[0])) {
+        $properties= $this->propertyManager->getProperties($args[0]);
+        // Avoid endless loops by limiting the token parsing depth
+        if ($properties instanceof ResolvingProperties) {
+          $properties= $properties->getDecoratedProperties();
+        }
+        $value= $properties->readString($args[1], $args[2], NULL);
+        if ($value === NULL) {
+          if ($default !== NULL) {
+            $value= $default;
+          } else {
+            throw new ElementNotFoundException(
+              'Can\'t find string "' . $args[2] . '" in section "' . $args[1]  . '"'
+            );
+          }
+        }
+      } else {
+        if ($default !== NULL) {
+          $value= $default;
+        } else {
+          throw new ElementNotFoundException(
+            'Can\'t find properties "' . $args[0] . '"'
+          );
+        }
+      }
+      return $value;
+    }
+
+    /**
+     * Processes the "env" token
+     *
+     * @param   string $arguments
+     * @param   string $default
+     * @return  string
+     * @throws  lang.ElementNotFoundException
+     */
+    private function processEnvToken($arguments, $default) {
+      $value= getenv($arguments);
+      if ($value === false) {
+        if ($default !== NULL) {
+          $value= $default;
+        } else {
+          throw new ElementNotFoundException(
+            'Environment variable "' . $arguments . '" doesn\'t exists'
+          );
+        }
+      }
+      return $value;
+    }
+
+  }

--- a/core/src/test/config/unittest/util.ini
+++ b/core/src/test/config/unittest/util.ini
@@ -62,3 +62,6 @@ class="net.xp_framework.unittest.util.BinfordTest"
 
 [objects]
 class="net.xp_framework.unittest.util.ObjectsTest"
+
+[resolvingproperties]
+class="net.xp_framework.unittest.util.ResolvingPropertiesTest"

--- a/core/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/util/PropertyManagerTest.class.php
@@ -2,6 +2,7 @@
 
 use unittest\TestCase;
 use util\PropertyManager;
+use util\PropertyDecorator;
 use util\ResourcePropertySource;
 use lang\ClassLoader;
 
@@ -102,10 +103,15 @@ class PropertyManagerTest extends TestCase {
   #[@test]
   public function getPropertiesReturnsSameObjectIfExactlyOneAvailable() {
     $fixture= $this->preconfigured();
-    $this->assertEquals(
-      $fixture->getProperties('example')->hashCode(),
-      $fixture->getProperties('example')->hashCode()
-    );
+    $prop1= $fixture->getProperties('example');
+    if ($prop1 instanceof PropertyDecorator) {
+      $prop1= $prop1->getDecoratedProperties();
+    }
+    $prop2= $fixture->getProperties('example');
+    if ($prop2 instanceof PropertyDecorator) {
+      $prop2= $prop2->getDecoratedProperties();
+    }
+    $this->assertEquals($prop1->hashCode(), $prop2->hashCode());
   }
   
   /**
@@ -255,6 +261,9 @@ class PropertyManagerTest extends TestCase {
 dynamic-value=whatever'));
 
     $prop= $fixture->getProperties('example');
+    if ($prop instanceof PropertyDecorator) {
+      $prop= $prop->getDecoratedProperties();
+    }
     $this->assertInstanceOf('util.PropertyAccess', $prop);
     $this->assertFalse($prop instanceof \util\Properties);
 
@@ -289,8 +298,11 @@ key="overwritten value"'));
     $fixture= $this->fixture();
     $fixture->appendSource(new ResourcePropertySource(self::RESOURCE_PATH));
     $fixture->appendSource(new ResourcePropertySource(self::RESOURCE_PATH));
-
-    $this->assertInstanceOf('util.Properties', $fixture->getProperties('example'));
+    $properties= $fixture->getProperties('example');
+    if ($properties instanceof PropertyDecorator) {
+      $properties= $properties->getDecoratedProperties();
+    }
+    $this->assertInstanceOf('util.Properties', $properties);
   }
 
   /**
@@ -300,6 +312,9 @@ key="overwritten value"'));
   #[@test]
   public function getExistantProperties() {
     $p= $this->preconfigured()->getProperties('example');
+    if ($p instanceof PropertyDecorator) {
+      $p= $p->getDecoratedProperties();
+    }
     $this->assertInstanceOf('util.Properties', $p);
     $this->assertTrue($p->exists(), 'Should return an existant Properties instance');
 

--- a/core/src/test/php/net/xp_framework/unittest/util/ResolvingPropertiesTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/util/ResolvingPropertiesTest.class.php
@@ -1,0 +1,158 @@
+<?php namespace net\xp_framework\unittest\util;
+
+use io\streams\MemoryInputStream;
+use unittest\TestCase;
+use util\ResolvingProperties;
+use util\Properties;
+use unittest\mock\MockRepository;
+
+/**
+ * Test for ResolvingProperties
+ *
+ * @see xp://util.ResolvingProperties
+ */
+class ResolvingPropertiesTest extends TestCase {
+
+  /**
+   * Creates a mock property manager
+   *
+   * @return  util.PropertyManager
+   */
+  private function getMockPropertyManager() {
+    $repo= new MockRepository();
+    $pm= $repo->createMock('util.PropertyManager', false);
+    return $pm;
+  }
+
+  /**
+   * Test parsing of the "prop" token
+   */
+  #[@test]
+  public function parsePropToken() {
+    $pm= $this->getMockPropertyManager();
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [childsection]
+      childvalue=childresult
+    '));
+    $pm->register('child', new ResolvingProperties($properties, $pm));
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [section]
+      value=${prop.child.childsection.childvalue}
+      value2=${prop.child.childsection.childvaluemissing|default}
+    '));
+    $pm->register('parent', new ResolvingProperties($properties, $pm));
+
+    $properties= $pm->getProperties('parent');
+
+    $this->assertEquals('childresult', $properties->readString('section', 'value'));
+    $this->assertEquals('default', $properties->readString('section', 'value2'));
+  }
+
+  /**
+   * Test parsing of the "prop" token failed because of of an missing properties
+   */
+  #[@test, @expect(class= 'lang.ElementNotFoundException', withMessage= 'Can\'t find properties')]
+  public function parsePropTokenMissingProperty() {
+    $pm= $this->getMockPropertyManager();
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [section]
+      value=${prop.is.missing.now}
+    '));
+    $pm->register('parent',  new ResolvingProperties($properties, $pm));
+
+    $properties= $pm->getProperties('parent');
+    $properties->readString('section', 'value');
+  }
+
+  /**
+   * Test parsing of the "prop" token failed because of an of missing string
+   */
+  #[@test, @expect(class= 'lang.ElementNotFoundException', withMessage= 'Can\'t find string')]
+  public function parsePropTokenMissingString() {
+    $pm= $this->getMockPropertyManager();
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [childsection]
+      childvalue=childresult
+    '));
+    $pm->register('child', new ResolvingProperties($properties));
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [section]
+      value=${prop.child.childsection.childvaluemissing}
+    '));
+    $pm->register('parent', new ResolvingProperties($properties, $pm));
+
+    $properties= $pm->getProperties('parent');
+    $properties->readString('section', 'value');
+  }
+
+  /**
+   * Test parsing of the "prop" token failed because of an invalid argument
+   */
+  #[@test, @expect(class= 'lang.FormatException', withMessage= 'Invalid arguments')]
+  public function parsePropTokenInvalidArg() {
+    $pm= $this->getMockPropertyManager();
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [section]
+      value=${prop.is.invalid}
+    '));
+    $pm->register('parent', new ResolvingProperties($properties, $pm));
+
+    $properties= $pm->getProperties('parent');
+    $properties->readString('section', 'value');
+  }
+
+  /**
+   * Test parsing of the "env" token
+   */
+  #[@test]
+  public function parseEnvToken() {
+    putenv("PARSEPROPTOKENTEST=result");
+    $pm= $this->getMockPropertyManager();
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [section]
+      value=${env.PARSEPROPTOKENTEST}
+      value2=${env.MISSINGENVVAR|default}
+    '));
+    $pm->register('properties', new ResolvingProperties($properties, $pm));
+
+    $properties= $pm->getProperties('properties');
+
+    $this->assertEquals('result', $properties->readString('section', 'value'));
+    $this->assertEquals('default', $properties->readString('section', 'value2'));
+  }
+
+  /**
+   * Test parsing of the "env" token failed because of an missing env var
+   */
+  #[@test, @expect(class= 'lang.ElementNotFoundException', withMessage= 'Environment variable')]
+  public function parseEnvTokenMissingEnv() {
+    putenv("PARSEPROPTOKENTEST=result");
+    $pm= $this->getMockPropertyManager();
+
+    $properties= new Properties(NULL);
+    $properties->load(new MemoryInputStream('
+      [section]
+      value=${env.MISSINGENVVAR}
+    '));
+    $pm->register('properties', new ResolvingProperties($properties, $pm));
+
+    $properties= $pm->getProperties('properties');
+    $properties->readString('section', 'value');
+  }
+
+}
+


### PR DESCRIPTION
A decorator for Properties, which allows to usage of tokens in property string variables. 

For example:

``` INI
[section]
val1=${prop.property.section.val} 
val2=${env.SERVER_PROFILE}
```

Also a default value can be supplied:
${prop.property.section.val|default}
If the token can't be resolved (missing property/missing env var) and there is no default value, an exeption will be thrown.
