### PR TITLE
- Invoke htmlspecialchars() w/ fixed encoding

### DIFF
--- a/core/src/main/php/text/doclet/markup/CodeProcessor.class.php
+++ b/core/src/main/php/text/doclet/markup/CodeProcessor.class.php
@@ -107,7 +107,7 @@
           $current= $class;
         }
 
-        $out.= strtr(htmlspecialchars(is_array($token) ? $token[1] : $token), array(
+        $out.= strtr(htmlspecialchars(is_array($token) ? $token[1] : $token, ENT_COMPAT, xp::ENCODING), array(
           "\n" => '<br/>',
           "\r" => ''
         ));

--- a/core/src/main/php/xml/io/XmlStreamWriter.class.php
+++ b/core/src/main/php/xml/io/XmlStreamWriter.class.php
@@ -59,7 +59,7 @@
     public function startElement($name, $attributes= array()) {
       $this->stream->write('<'.$name);
       foreach ($attributes as $key => $value) {
-        $this->stream->write(' '.$key.'="'.htmlspecialchars($value).'"');
+        $this->stream->write(' '.$key.'="'.htmlspecialchars($value, ENT_COMPAT, xp::ENCODING).'"');
       }
       $this->stream->write('>');
       $this->stack[]= '</'.$name.'>';
@@ -151,7 +151,7 @@
      * @param   string content
      */
     public function writeText($content) {
-      $this->stream->write(htmlspecialchars($content));
+      $this->stream->write(htmlspecialchars($content, ENT_COMPAT, xp::ENCODING));
     }
 
     /**
@@ -193,7 +193,7 @@
       $this->stream->write('<?'.$target);
       if (is_array($content)) {
         foreach ($content as $key => $value) {
-          $this->stream->write(' '.$key.'="'.htmlspecialchars($value).'"');
+          $this->stream->write(' '.$key.'="'.htmlspecialchars($value, ENT_COMPAT, xp::ENCODING).'"');
         }
         $this->stream->write('?>');
       } else {
@@ -211,13 +211,13 @@
     public function writeElement($name, $content= NULL, $attributes= array()) {
       $this->stream->write('<'.$name);
       foreach ($attributes as $key => $value) {
-        $this->stream->write(' '.$key.'="'.htmlspecialchars($value).'"');
+        $this->stream->write(' '.$key.'="'.htmlspecialchars($value, ENT_COMPAT, xp::ENCODING).'"');
       }
       
       if (NULL === $content) {
         $this->stream->write('/>');
       } else {
-        $this->stream->write('>'.htmlspecialchars($content).'</'.$name.'>');
+        $this->stream->write('>'.htmlspecialchars($content, ENT_COMPAT, xp::ENCODING).'</'.$name.'>');
       }
     }
   }


### PR DESCRIPTION
PHP defaults differ through the versions:
  . <= 5.3 uses iso-8859-1
  . 5.4, 5.5 uses utf-8
  . 5.6 uses "default_encoding"
