### PR TITLE
Change XML debug output format to valid <div> tag

### DIFF
--- a/core/src/main/php/scriptlet/HttpScriptlet.class.php
+++ b/core/src/main/php/scriptlet/HttpScriptlet.class.php
@@ -44,6 +44,11 @@
    * @test    xp://net.xp_framework.unittest.scriptlet.HttpScriptletProcessTest
    */
   class HttpScriptlet extends Object {
+
+    // Constants from \xp\scriptlet\Runner
+    const
+      XML         = 0x0001,
+      ERRORS      = 0x0002;
     
     /**
      * Create a request object. Override this method to define
@@ -457,6 +462,24 @@
       
       // Return it
       return $response;
+    }
+
+    /**
+     * At the end of request, perform a "trace" of the processing; this
+     * method will be called for debugging purposes, invoked only on non-
+     * production systems.
+     *
+     * No business logic to be taking place here!
+     *
+     * @param  int flags
+     * @param  scriptlet.HttpScriptletResponse response
+     * @param  var* errors
+     */
+    public function trace($flags, $response, $errors) {
+      if (($flags & self::ERRORS) && sizeof(\xp::$errors)) {
+        flush();
+        echo '<xmp>', \xp::stringOf(\xp::$errors), '</xmp>';
+      }
     }
   }
 ?>

--- a/core/src/main/php/scriptlet/xml/XMLScriptlet.class.php
+++ b/core/src/main/php/scriptlet/xml/XMLScriptlet.class.php
@@ -263,7 +263,7 @@
         '</xmp>';
       }
 
-      parent::trace($flags, $request, $response, $errors);
+      parent::trace($flags, $response, $errors);
     }
   }
 ?>

--- a/core/src/main/php/scriptlet/xml/XMLScriptlet.class.php
+++ b/core/src/main/php/scriptlet/xml/XMLScriptlet.class.php
@@ -239,5 +239,31 @@
     public function doPost($request, $response) {
       return $this->processRequest($request, $response);
     }
+
+
+    /**
+     * At the end of request, perform a "trace" of the processing; this
+     * method will be called for debugging purposes, invoked only on non-
+     * production systems.
+     *
+     * No business logic to be taking place here!
+     *
+     * @param  int flags
+     * @param  scriptlet.HttpScriptletResponse response
+     * @param  var* errors
+     */
+    public function trace($flags, $response, $errors) {
+
+      // Debugging
+      if (($flags & self::XML) && isset($response->document)) {
+        flush();
+        echo '<xmp>',
+          $response->document->getDeclaration()."\n".
+          $response->document->getSource(0),
+        '</xmp>';
+      }
+
+      parent::trace($flags, $request, $response, $errors);
+    }
   }
 ?>

--- a/core/src/main/php/xp/scriptlet/Runner.class.php
+++ b/core/src/main/php/xp/scriptlet/Runner.class.php
@@ -231,21 +231,9 @@ class Runner extends \lang\Object {
     // Call scriptlet's finalizer
     $instance && $instance->finalize();
 
-    // Debugging
-    if (($flags & WebDebug::XML) && isset($response->document)) {
-      flush();
-      echo '<div id="xp-debug-xml" style="display: none;">', rawurlencode(
-        $response->document->getDeclaration()."\n".
-        $response->document->getSource(0)),
-      '</div>';
-    }
-    
-    if (($flags & WebDebug::ERRORS) && sizeof(\xp::$errors)) {
-      flush();
-      echo '<div id="xp-debug-errors" style="display: none;">',
-        $e ? rawurlencode($e->toString()) : '',
-        rawurlencode(\xp::stringOf(\xp::$errors)),
-      '</div>';
+    // Call scriptlet's trace method
+    if ($flags & WebDebug::XML || $flags & WebDebug::ERRORS) {
+      $instance->trace($flags, $response, \xp::$errors);
     }
   }
 

--- a/core/src/main/php/xp/scriptlet/Runner.class.php
+++ b/core/src/main/php/xp/scriptlet/Runner.class.php
@@ -234,12 +234,18 @@ class Runner extends \lang\Object {
     // Debugging
     if (($flags & WebDebug::XML) && isset($response->document)) {
       flush();
-      echo '<xmp>', $response->document->getDeclaration()."\n".$response->document->getSource(0), '</xmp>';
+      echo '<div id="xp-debug-xml" style="display: none;">', rawurlencode(
+        $response->document->getDeclaration()."\n".
+        $response->document->getSource(0)),
+      '</div>';
     }
     
-    if (($flags & WebDebug::ERRORS)) {
+    if (($flags & WebDebug::ERRORS) && sizeof(\xp::$errors)) {
       flush();
-      echo '<xmp>', $e ? $e->toString() : '', \xp::stringOf(\xp::$errors), '</xmp>';
+      echo '<div id="xp-debug-errors" style="display: none;">',
+        $e ? rawurlencode($e->toString()) : '',
+        rawurlencode(\xp::stringOf(\xp::$errors)),
+      '</div>';
     }
   }
 


### PR DESCRIPTION
This used to be output in a non-standard compliant <xmp> tag, as plain
XML output (which also lead to some HTML validators to complain about
these XML tags in an HTML document).

Now it will be the app's responsibility to render these debug information
usefully.
