### PR TITLE
rfc: Entity validator 

### DIFF
--- a/core/src/main/php/validation/ConstraintValidator.class.php
+++ b/core/src/main/php/validation/ConstraintValidator.class.php
@@ -1,0 +1,31 @@
+<?php namespace validation;
+
+/**
+ * Interface ConstraintValidator
+ *
+ * @author jzinnau
+ *
+ */
+abstract class ConstraintValidator {
+
+  protected $context;
+  protected $options;
+  protected $continue;
+
+  public function __construct(ValidationContext $context, array $params) {
+    $this->context= $context;
+    $this->options= array_merge($this->getDefaultOptions(), $params);
+    $this->continue= isset($this->options['continue']) && $this->options['continue'];
+  }
+
+  protected function getDefaultOptions() {
+    return array();
+  }
+
+  public function continueValidationAfterViolation() {
+    return $this->continue;
+  }
+
+  public abstract function validate($object);
+
+}

--- a/core/src/main/php/validation/ConstraintValidator.class.php
+++ b/core/src/main/php/validation/ConstraintValidator.class.php
@@ -18,14 +18,30 @@ abstract class ConstraintValidator {
     $this->continue= isset($this->options['continue']) && $this->options['continue'];
   }
 
+  /**
+   * Overwrite to define the options for the validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array();
   }
 
+  /**
+   * Returns true if the validation should continue after one constraint faild for a field
+   *
+   * @return bool
+   */
   public function continueValidationAfterViolation() {
     return $this->continue;
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public abstract function validate($object);
 
 }

--- a/core/src/main/php/validation/EntityValidationException.class.php
+++ b/core/src/main/php/validation/EntityValidationException.class.php
@@ -1,0 +1,13 @@
+<?php namespace validation;
+
+use lang\XPException;
+
+/**
+ * Class EntityValidationException
+ *
+ * @author jzinnau
+ *
+ */
+class EntityValidationException extends XPException {
+
+}

--- a/core/src/main/php/validation/EntityValidator.class.php
+++ b/core/src/main/php/validation/EntityValidator.class.php
@@ -1,0 +1,69 @@
+<?php namespace validation;
+
+use lang\Object;
+use lang\reflect\Field;
+use lang\XPClass;
+
+/**
+ * Class validator
+ *
+ * @author jzinnau
+ *
+ */
+class EntityValidator extends Object {
+
+  const ASSERT_ANNOTATION_NAME= 'Assert';
+
+  /**
+   * Validates object against constraints defined in its annotations
+   *
+   * @param Object $entity
+   * @return ValidationResult
+   * @throws EntityValidationException
+   */
+  public function validate(Object $entity) {
+    $result= new ValidationResult();
+
+    /** @var XPClass $class */
+    $class= $entity->getClass();
+    $fields= $class->getFields();
+
+    /** @var Field $field */
+    foreach ($fields as $field) {
+      if ($field->hasAnnotations() && $field->hasAnnotation(self::ASSERT_ANNOTATION_NAME)) {
+        $fieldName= $field->getName();
+        $getterMethodName= 'get'.ucfirst($field->getName());
+        $fieldValue= $class->hasMethod($getterMethodName) ?
+          $entity->$getterMethodName() :
+          $entity->$fieldName;
+        $context= new ValidationContext($fieldName);
+
+        $annotation= $field->getAnnotation(self::ASSERT_ANNOTATION_NAME);
+        if (!is_array($annotation)) {
+          throw new EntityValidationException('Invalid assert annotation format (no array)');
+        }
+       /* if (isset($annotation['type'])) {
+          $annotation= array($annotation);
+        }*/
+
+        foreach ($annotation as $assert) {
+          $constraintValidator= XPClass::forName($assert['type'])->newInstance(
+            $context,
+            $assert
+          );
+          $valid= $constraintValidator->validate($entity->$fieldName);
+          if (!$valid && $constraintValidator->continueValidationAfterViolation() == false) {
+            break;
+          }
+        }
+
+        if ($context->hasViolations()) {
+          $result->addContextResults($context);
+        }
+      }
+    }
+
+    return $result;
+  }
+
+}

--- a/core/src/main/php/validation/ValidationContext.class.php
+++ b/core/src/main/php/validation/ValidationContext.class.php
@@ -1,10 +1,9 @@
 <?php namespace validation;
 
 /**
- * Class FieldValidationContext
- *
- * @author jzinnau
- *
+ * While validating, every field has a context in which the violations will be stored.
+ * After a field is validated, the field name and violations will be written
+ * into the validation result.
  */
 class ValidationContext {
 
@@ -16,18 +15,32 @@ class ValidationContext {
     $this->violations= array();
   }
 
+  /**
+   * Returns the field name, this context applies to
+   *
+   * @return mixed
+   */
   public function getFieldName() {
     return $this->fieldName;
   }
 
+  /**
+   * @return bool
+   */
   public function hasViolations() {
     return count($this->violations) > 0;
   }
 
+  /**
+   * @return array
+   */
   public function getViolations() {
     return $this->violations;
   }
 
+  /**
+   * @param Violation $violation
+   */
   public function addViolation(Violation $violation) {
     $this->violations[]= $violation;
   }

--- a/core/src/main/php/validation/ValidationContext.class.php
+++ b/core/src/main/php/validation/ValidationContext.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation;
+
+/**
+ * Class FieldValidationContext
+ *
+ * @author jzinnau
+ *
+ */
+class ValidationContext {
+
+  private $fieldName;
+  private $violations;
+
+  public function __construct($fieldName) {
+    $this->fieldName= $fieldName;
+    $this->violations= array();
+  }
+
+  public function getFieldName() {
+    return $this->fieldName;
+  }
+
+  public function hasViolations() {
+    return count($this->violations) > 0;
+  }
+
+  public function getViolations() {
+    return $this->violations;
+  }
+
+  public function addViolation(Violation $violation) {
+    $this->violations[]= $violation;
+  }
+
+}

--- a/core/src/main/php/validation/ValidationResult.class.php
+++ b/core/src/main/php/validation/ValidationResult.class.php
@@ -11,29 +11,69 @@ use lang\Object;
 class ValidationResult extends Object {
 
   private $violations;
+  private $isValid;
 
   public function __construct() {
     $this->violations= array();
   }
 
+  /**
+   * Indicate, that the validation has faild
+   */
+  public function setInvalid() {
+    $this->isValid= false;
+  }
+
+  /**
+   * Indicate, that the validation has succeeded
+   */
+  public function setValid() {
+    $this->isValid= true;
+  }
+
+  /**
+   * Returns true if there where violations against the constraints of an object.
+   * This can be true, even if there are no actual violation objects (this happens when
+   * a validator isn't returning a violation).
+   *
+   * @return mixed
+   */
   public function isValid() {
-    return count($this->violations) == 0;
+    return $this->isValid;
   }
 
+  /**
+   * Adds the violations of a validation context to the result
+   *
+   * @param ValidationContext $context
+   */
   public function addContextResults(ValidationContext $context) {
-    if (!isset($this->violations[$context->getFieldName()])) {
-      $this->violations[$context->getFieldName()]= array();
+    if ($context->hasViolations()) {
+      $this->setInvalid();
+      if (!isset($this->violations[$context->getFieldName()])) {
+        $this->violations[$context->getFieldName()]= array();
+      }
+      $this->violations[$context->getFieldName()]= array_merge(
+        $this->violations[$context->getFieldName()],
+        $context->getViolations()
+      );
     }
-    $this->violations[$context->getFieldName()]= array_merge(
-      $this->violations[$context->getFieldName()],
-      $context->getViolations()
-    );
   }
 
+  /**
+   * Returns all violation objects sorted by the field names
+   *
+   * @return array
+   */
   public function getViolations() {
     return $this->violations;
   }
 
+  /**
+   * Returns the array representation of all violation objects sorted by the field names
+   *
+   * @return array
+   */
   public function getViolationsArray() {
     $return= array();
 

--- a/core/src/main/php/validation/ValidationResult.class.php
+++ b/core/src/main/php/validation/ValidationResult.class.php
@@ -1,0 +1,50 @@
+<?php namespace validation;
+
+use lang\Object;
+
+/**
+ * Class validationResult
+ *
+ * @author jzinnau
+ *
+ */
+class ValidationResult extends Object {
+
+  private $violations;
+
+  public function __construct() {
+    $this->violations= array();
+  }
+
+  public function isValid() {
+    return count($this->violations) == 0;
+  }
+
+  public function addContextResults(ValidationContext $context) {
+    if (!isset($this->violations[$context->getFieldName()])) {
+      $this->violations[$context->getFieldName()]= array();
+    }
+    $this->violations[$context->getFieldName()]= array_merge(
+      $this->violations[$context->getFieldName()],
+      $context->getViolations()
+    );
+  }
+
+  public function getViolations() {
+    return $this->violations;
+  }
+
+  public function getViolationsArray() {
+    $return= array();
+
+    foreach ($this->violations as $field => $violations) {
+      $return[$field]= array();
+      foreach ($violations as $violation) {
+        $return[$field][]= $violation->toArray();
+      }
+    }
+
+    return $return;
+  }
+
+}

--- a/core/src/main/php/validation/ValidationResult.class.php
+++ b/core/src/main/php/validation/ValidationResult.class.php
@@ -3,10 +3,7 @@
 use lang\Object;
 
 /**
- * Class validationResult
- *
- * @author jzinnau
- *
+ * ValidationResult object
  */
 class ValidationResult extends Object {
 

--- a/core/src/main/php/validation/Violation.class.php
+++ b/core/src/main/php/validation/Violation.class.php
@@ -1,0 +1,54 @@
+<?php namespace validation;
+
+/**
+ * Class Violation
+ *
+ * @author jzinnau
+ *
+ */
+class Violation {
+
+  private $code;
+  private $message;
+
+  public function __construct($code, $message) {
+    $this->code= $code;
+    $this->message= $message;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCode() {
+    return $this->code;
+  }
+
+  /**
+   * @param string $code
+   */
+  public function setCode($code) {
+    $this->code= $code;
+  }
+
+  /**
+   * @return string
+   */
+  public function getMessage() {
+    return $this->message;
+  }
+
+  /**
+   * @param string $message
+   */
+  public function setMessage($message) {
+    $this->message= $message;
+  }
+
+  public function toArray() {
+    return array(
+      'code' => $this->getCode(),
+      'message' => $this->getMessage()
+    );
+  }
+
+}

--- a/core/src/main/php/validation/Violation.class.php
+++ b/core/src/main/php/validation/Violation.class.php
@@ -1,10 +1,7 @@
 <?php namespace validation;
 
 /**
- * Class Violation
- *
- * @author jzinnau
- *
+ * Object representation of a copnstraint violation
  */
 class Violation {
 
@@ -44,6 +41,9 @@ class Violation {
     $this->message= $message;
   }
 
+  /**
+   * @return array
+   */
   public function toArray() {
     return array(
       'code' => $this->getCode(),

--- a/core/src/main/php/validation/constraints/Blank.class.php
+++ b/core/src/main/php/validation/constraints/Blank.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class Blank
+ *
+ * @author jzinnau
+ *
+ */
+class Blank extends ConstraintValidator {
+
+  const VIOLATION_TYPE_BLANK= 'blank';
+
+  protected function getDefaultOptions() {
+    return array(
+      'message' => 'validation#blank'
+    );
+  }
+
+  public function validate($object) {
+    if ($object !== null && $object !== '') {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_BLANK,
+          $this->options['message']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/Blank.class.php
+++ b/core/src/main/php/validation/constraints/Blank.class.php
@@ -4,21 +4,36 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class Blank
+ * Checks if a value is a blank string or null
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.Blank')
+ * #])]
+ * ```
  */
 class Blank extends ConstraintValidator {
 
   const VIOLATION_TYPE_BLANK= 'blank';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'message' => 'validation#blank'
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if ($object !== null && $object !== '') {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/False.class.php
+++ b/core/src/main/php/validation/constraints/False.class.php
@@ -4,21 +4,36 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class False
+ * Checks if a value is false
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.False')
+ * #])]
+ * ```
  */
 class False extends ConstraintValidator {
 
   const VIOLATION_TYPE_FALSE= 'false';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'message' => 'validation#false'
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if ($object !== false) {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/False.class.php
+++ b/core/src/main/php/validation/constraints/False.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class False
+ *
+ * @author jzinnau
+ *
+ */
+class False extends ConstraintValidator {
+
+  const VIOLATION_TYPE_FALSE= 'false';
+
+  protected function getDefaultOptions() {
+    return array(
+      'message' => 'validation#false'
+    );
+  }
+
+  public function validate($object) {
+    if ($object !== false) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_FALSE,
+          $this->options['message']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/Length.class.php
+++ b/core/src/main/php/validation/constraints/Length.class.php
@@ -1,0 +1,48 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class Length
+ *
+ * @author jzinnau
+ *
+ */
+class Length extends ConstraintValidator {
+
+  const VIOLATION_TYPE_TOOLONG= 'length_toolow';
+  const VIOLATION_TYPE_TOOSHORT= 'length_tooshort';
+
+  protected function getDefaultOptions() {
+    return array(
+      'min'             => 0,
+      'max'             => 100,
+      'messageTooLong'  => 'validation#length.toolong',
+      'messageTooShort' => 'validation#length.tooshort'
+    );
+  }
+
+  public function validate($object) {
+    if (mb_strlen($object, \XP::ENCODING) < $this->options['min']) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_TOOSHORT,
+          $this->options['messageTooShort']
+        )
+      );
+      return false;
+    }
+    if (mb_strlen($object, \XP::ENCODING) > $this->options['max']) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_TOOLONG,
+          $this->options['messageTooLong']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/Length.class.php
+++ b/core/src/main/php/validation/constraints/Length.class.php
@@ -4,16 +4,27 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class Length
+ * Checks the lenght of a string value.
+ * The allowed length can be set by the 'min' and 'max' parameters.
+ * If one parameter is set to null, this constraint will be ignored.
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.Length', 'min'=>1, 'max'=>100)
+ * #])]
+ * ```
  */
 class Length extends ConstraintValidator {
 
   const VIOLATION_TYPE_TOOLONG= 'length_toolow';
   const VIOLATION_TYPE_TOOSHORT= 'length_tooshort';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'min'             => 0,
@@ -23,6 +34,12 @@ class Length extends ConstraintValidator {
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if (mb_strlen($object, \XP::ENCODING) < $this->options['min']) {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/NotBlank.class.php
+++ b/core/src/main/php/validation/constraints/NotBlank.class.php
@@ -4,21 +4,36 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class NotBlank
+ * Checks if a value is not null and not an empty string
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.NotBlank')
+ * #])]
+ * ```
  */
 class NotBlank extends ConstraintValidator {
 
   const VIOLATION_TYPE_NOTBLANK= 'notblank';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'message' => 'validation#notblank'
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if ($object === null || $object === '') {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/NotBlank.class.php
+++ b/core/src/main/php/validation/constraints/NotBlank.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class NotBlank
+ *
+ * @author jzinnau
+ *
+ */
+class NotBlank extends ConstraintValidator {
+
+  const VIOLATION_TYPE_NOTBLANK= 'notblank';
+
+  protected function getDefaultOptions() {
+    return array(
+      'message' => 'validation#notblank'
+    );
+  }
+
+  public function validate($object) {
+    if ($object === null || $object === '') {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_NOTBLANK,
+          $this->options['message']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/NotNull.class.php
+++ b/core/src/main/php/validation/constraints/NotNull.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class NotNull
+ *
+ * @author jzinnau
+ *
+ */
+class NotNull extends ConstraintValidator {
+
+  const VIOLATION_TYPE_NOTNULL= 'notnull';
+
+  protected function getDefaultOptions() {
+    return array(
+      'message' => 'validation#notnull'
+    );
+  }
+
+  public function validate($object) {
+    if ($object === null) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_NOTNULL,
+          $this->options['message']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/NotNull.class.php
+++ b/core/src/main/php/validation/constraints/NotNull.class.php
@@ -4,21 +4,36 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class NotNull
+ * Checks if a value is not null
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.NotNull')
+ * #])]
+ * ```
  */
 class NotNull extends ConstraintValidator {
 
   const VIOLATION_TYPE_NOTNULL= 'notnull';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'message' => 'validation#notnull'
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if ($object === null) {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/Null.class.php
+++ b/core/src/main/php/validation/constraints/Null.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class Null
+ *
+ * @author jzinnau
+ *
+ */
+class Null extends ConstraintValidator {
+
+  const VIOLATION_TYPE_NULL= 'null';
+
+  protected function getDefaultOptions() {
+    return array(
+      'message' => 'validation#null'
+    );
+  }
+
+  public function validate($object) {
+    if ($object !== null) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_NULL,
+          $this->options['message']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/Null.class.php
+++ b/core/src/main/php/validation/constraints/Null.class.php
@@ -4,21 +4,36 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class Null
+ * Checks if a value is null
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.Null')
+ * #])]
+ * ```
  */
 class Null extends ConstraintValidator {
 
   const VIOLATION_TYPE_NULL= 'null';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'message' => 'validation#null'
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if ($object !== null) {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/Numeric.class.php
+++ b/core/src/main/php/validation/constraints/Numeric.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class Numerics
+ *
+ * @author jzinnau
+ *
+ */
+class Numeric extends ConstraintValidator {
+
+  const VIOLATION_TYPE_NUMERIC= 'numeric';
+
+  protected function getDefaultOptions() {
+    return array(
+      'message' => 'validation#numeric'
+    );
+  }
+
+  public function validate($object) {
+    if (!is_numeric($object)) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_NUMERIC,
+          $this->options['message']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/Numeric.class.php
+++ b/core/src/main/php/validation/constraints/Numeric.class.php
@@ -4,21 +4,36 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class Numerics
+ * Checks if a value is numeric
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.Numeric')
+ * #])]
+ * ```
  */
 class Numeric extends ConstraintValidator {
 
   const VIOLATION_TYPE_NUMERIC= 'numeric';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'message' => 'validation#numeric'
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if (!is_numeric($object)) {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/Range.class.php
+++ b/core/src/main/php/validation/constraints/Range.class.php
@@ -4,16 +4,27 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class Range
+ * Checks if a numeric value is in a specific range
+ * The allowed range can be set by the 'min' and 'max' parameters.
+ * If one parameter is set to null, this constraint will be ignored.
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.Range')
+ * #])]
+ * ```
  */
 class Range extends ConstraintValidator {
 
   const VIOLATION_TYPE_TOOLOW= 'range_toolow';
   const VIOLATION_TYPE_TOOHIGH= 'range_toohigh';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'min'             => 0,
@@ -23,6 +34,12 @@ class Range extends ConstraintValidator {
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if ($this->options['min'] != null && $object < $this->options['min']) {
       $this->context->addViolation(

--- a/core/src/main/php/validation/constraints/Range.class.php
+++ b/core/src/main/php/validation/constraints/Range.class.php
@@ -1,0 +1,48 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class Range
+ *
+ * @author jzinnau
+ *
+ */
+class Range extends ConstraintValidator {
+
+  const VIOLATION_TYPE_TOOLOW= 'range_toolow';
+  const VIOLATION_TYPE_TOOHIGH= 'range_toohigh';
+
+  protected function getDefaultOptions() {
+    return array(
+      'min'             => 0,
+      'max'             => 100,
+      'messageTooLow'   => 'validation#length.toolow',
+      'messageTooHigh'  => 'validation#length.toohigh'
+    );
+  }
+
+  public function validate($object) {
+    if ($this->options['min'] != null && $object < $this->options['min']) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_TOOLOW,
+          $this->options['messageTooLow']
+        )
+      );
+      return false;
+    }
+    if ($this->options['max'] != null && $object > $this->options['max']) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_TOOHIGH,
+          $this->options['messageTooHigh']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/True.class.php
+++ b/core/src/main/php/validation/constraints/True.class.php
@@ -1,0 +1,35 @@
+<?php namespace validation\constraints;
+
+use validation\ConstraintValidator;
+use validation\Violation;
+
+/**
+ * Class True
+ *
+ * @author jzinnau
+ *
+ */
+class True extends ConstraintValidator {
+
+  const VIOLATION_TYPE_TRUE= 'true';
+
+  protected function getDefaultOptions() {
+    return array(
+      'message' => 'validation#true'
+    );
+  }
+
+  public function validate($object) {
+    if ($object !== true) {
+      $this->context->addViolation(
+        new Violation(
+          self::VIOLATION_TYPE_TRUE,
+          $this->options['message']
+        )
+      );
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/core/src/main/php/validation/constraints/True.class.php
+++ b/core/src/main/php/validation/constraints/True.class.php
@@ -4,21 +4,36 @@ use validation\ConstraintValidator;
 use validation\Violation;
 
 /**
- * Class True
+ * Checks if a value is true
  *
- * @author jzinnau
- *
+ * Example:
+ * ```
+ * #[@Assert([
+ * # array('type'=>'validation.constraints.True')
+ * #])]
+ * ```
  */
 class True extends ConstraintValidator {
 
   const VIOLATION_TYPE_TRUE= 'true';
 
+  /**
+   * Returns default options for this validator
+   *
+   * @return array
+   */
   protected function getDefaultOptions() {
     return array(
       'message' => 'validation#true'
     );
   }
 
+  /**
+   * Returns true if the object is valid.
+   *
+   * @param $object
+   * @return bool
+   */
   public function validate($object) {
     if ($object !== true) {
       $this->context->addViolation(


### PR DESCRIPTION
Since there isn't a standard way to validate entities submitted to a REST endpoint, I implemented a way to validate entities via constraints defined in its member variables:

```
class Admin extends Object {

  #[@Assert(type='validation.constraints.NotNull')]
  public $id;

  #[@Assert([
  # array('type'=>'validation.constraints.NotBlank'),
  # array('type'=>'validation.constraints.Numeric'),
  # array('type'=>'validation.constraints.Range', 'min'=>1, 'max'=>null, 'message'=>'message.text')
  #])]
  public $userId;
```

Now this entity can be validated via the EntityValidator:
```
$validator= new EntityValidator();
$validationResult= $validator->validate($admin);
```

I think this validater could be also integrated in the REST server, so valid entities can be enforced.
One possibility could be, to add a new parame ter to the "webmethod" annotation:
```
#[@webmethod(verb= 'POST', returns = 'application/json', path= '/{id}', valid= true)]
```
Or an additional annotation:
```
#[@validate]
```
