### PR TITLE
Implement optional parameter encoding to RestResponse::data()

### DIFF
--- a/core/src/main/php/webservices/rest/ResponseReader.class.php
+++ b/core/src/main/php/webservices/rest/ResponseReader.class.php
@@ -27,10 +27,11 @@
      *
      * @param  lang.Type $t
      * @param  io.streams.InputStream $is
+     * @param   string $encoding
      * @return var
      */
-    public function read(Type $t, InputStream $is) {
-      return $this->marshalling->unmarshal($t, $this->deserializer->deserialize($is));
+    public function read(Type $t, InputStream $is, $encoding= xp::ENCODING) {
+      return $this->marshalling->unmarshal($t, $this->deserializer->deserialize($is, $encoding));
     }
   }
 ?>

--- a/core/src/main/php/webservices/rest/RestDeserializer.class.php
+++ b/core/src/main/php/webservices/rest/RestDeserializer.class.php
@@ -21,9 +21,10 @@
      * Deserialize
      *
      * @param   io.streams.InputStream in
+     * @param   string $encoding
      * @return  var
      * @throws  lang.FormatException
      */
-    public abstract function deserialize($in);
+    public abstract function deserialize($in, $encoding= xp::ENCODING);
   }
 ?>

--- a/core/src/main/php/webservices/rest/RestFormDeserializer.class.php
+++ b/core/src/main/php/webservices/rest/RestFormDeserializer.class.php
@@ -18,10 +18,11 @@
      * Deserialize
      *
      * @param   io.streams.InputStream in
+     * @param   string $encoding
      * @return  var
      * @throws  lang.FormatException
      */
-    public function deserialize($in) {
+    public function deserialize($in, $encoding= xp::ENCODING) {
       $st= new StreamTokenizer($in, '&');
       $map= array();
       while ($st->hasMoreTokens()) {

--- a/core/src/main/php/webservices/rest/RestJsonDeserializer.class.php
+++ b/core/src/main/php/webservices/rest/RestJsonDeserializer.class.php
@@ -26,12 +26,13 @@
      * Deserialize
      *
      * @param   io.streams.InputStream in
+     * @param   string $encoding
      * @return  var
      * @throws  lang.FormatException
      */
-    public function deserialize($in) {
+    public function deserialize($in, $encoding= xp::ENCODING) {
       try {
-        return $this->json->decodeFrom($in);
+        return $this->json->decodeFrom($in, $encoding);
       } catch (JsonException $e) {
         throw new FormatException('Malformed JSON', $e);
       }

--- a/core/src/main/php/webservices/rest/RestResponse.class.php
+++ b/core/src/main/php/webservices/rest/RestResponse.class.php
@@ -131,20 +131,22 @@
      * passed target type. Overwrite in subclasses to change this behaviour.
      *
      * @param   lang.Type target
+     * @param   string $encoding
      * @return  var
      */
-    protected function handlePayloadOf($target) {
-      return $this->reader->read($target, $this->input);
+    protected function handlePayloadOf($target, $encoding= xp::ENCODING) {
+      return $this->reader->read($target, $this->input, $encoding);
     }
 
     /**
      * Get data
      *
      * @param   var type target type of deserialization, either a lang.Type or a string
+     * @param   string $encoding
      * @return  var
      * @throws  webservices.rest.RestException if the status code is > 399
      */
-    public function data($type= NULL) {
+    public function data($type= NULL, $encoding= xp::ENCODING) {
       $this->handleStatus($this->response->statusCode());
  
       if (NULL === $type) {
@@ -159,7 +161,7 @@
         throw new IllegalArgumentException('Unknown content type "'.$this->headers['Content-Type'][0].'"');
       }
 
-      return $this->handlePayloadOf($target);
+      return $this->handlePayloadOf($target, $encoding);
     }
 
     /**

--- a/core/src/main/php/webservices/rest/RestXmlDeserializer.class.php
+++ b/core/src/main/php/webservices/rest/RestXmlDeserializer.class.php
@@ -24,12 +24,13 @@
      * Deserialize
      *
      * @param   io.streams.InputStream in
+     * @param   string $encoding
      * @return  var
      * @throws  lang.FormatException
      */
-    public function deserialize($in) {
+    public function deserialize($in, $encoding= xp::ENCODING) {
       $tree= new Tree();
-      create(new XMLParser())->withCallback($tree)->parse(new StreamInputSource($in));
+      create(new XMLParser($encoding))->withCallback($tree)->parse(new StreamInputSource($in));
       return new RestXmlMap($tree->root);
     }
   }

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/CustomRestResponse.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/CustomRestResponse.class.php
@@ -27,9 +27,10 @@ class CustomRestResponse extends RestResponse {
    * Handle payload
    * 
    * @param   lang.Type target
+   * @param   string $encoding
    * @return  var
    */
-  protected function handlePayloadOf($target) {
+  protected function handlePayloadOf($target, $encoding= xp::ENCODING) {
     if (204 === $this->response->statusCode()) {
       return null;  // "No Content"
     } else {

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestDeserializerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestDeserializerTest.class.php
@@ -4,7 +4,6 @@ use unittest\TestCase;
 use webservices\rest\RestJsonDeserializer;
 use io\streams\MemoryInputStream;
 
-
 /**
  * TestCase
  *
@@ -15,7 +14,6 @@ abstract class RestDeserializerTest extends TestCase {
 
   /**
    * Sets up test case
-   *
    */
   public function setUp() {
     $this->fixture= $this->newFixture();
@@ -29,7 +27,7 @@ abstract class RestDeserializerTest extends TestCase {
   protected abstract function newFixture();
 
   /**
-   * CReates an input stream
+   * Creates an input stream
    *
    * @param   string bytes
    * @return  io.streams.MemoryInputStream
@@ -38,12 +36,8 @@ abstract class RestDeserializerTest extends TestCase {
     return new MemoryInputStream($bytes);
   }
   
-  /**
-   * Test empty input
-   *
-   */
   #[@test, @expect('lang.FormatException')]
   public function empty_content() {
-    $this->fixture->deserialize($this->input(''), \lang\Type::$VAR);
+    $this->fixture->deserialize($this->input(''));
   }
 }

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestJsonDeserializerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestJsonDeserializerTest.class.php
@@ -7,6 +7,7 @@ use webservices\rest\RestJsonDeserializer;
  * TestCase
  *
  * @see   xp://webservices.rest.RestJsonDeserializer
+ * @see   https://github.com/xp-framework/xp-framework/issues/362
  */
 class RestJsonDeserializerTest extends RestDeserializerTest {
 
@@ -19,10 +20,6 @@ class RestJsonDeserializerTest extends RestDeserializerTest {
     return new RestJsonDeserializer();
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function one_keyvalue_pair() {
     $this->assertEquals(
@@ -31,15 +28,19 @@ class RestJsonDeserializerTest extends RestDeserializerTest {
     );
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function two_keyvalue_pairs() {
     $this->assertEquals(
       array('name' => 'Timm', 'id' => '1549'), 
       $this->fixture->deserialize($this->input('{ "name" : "Timm", "id" : "1549" }'))
+    );
+  }
+
+  #[@test]
+  public function deserialize_unicode() {
+    $this->assertEquals(
+      array('en-dash' => '–'),
+      $this->fixture->deserialize($this->input('{ "en-dash" : "\u2013" }'), 'utf-8')
     );
   }
 }

--- a/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestXmlDeserializerTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/webservices/rest/RestXmlDeserializerTest.class.php
@@ -48,4 +48,12 @@ class RestXmlDeserializerTest extends RestDeserializerTest {
       $this->flatten($this->fixture->deserialize($this->input('<root><name>Timm</name><id>1549</id></root>')))
     );
   }
+
+  #[@test]
+  public function deserialize_unicode() {
+    $this->assertEquals(
+      array('en-dash' => '–'),
+      $this->flatten($this->fixture->deserialize($this->input('<root><en-dash>&#x2013;</en-dash></root>'), 'utf-8'))
+    );
+  }
 }


### PR DESCRIPTION
See https://github.com/xp-framework/xp-framework/issues/362

## Old behaviour
```sh
$ echo '{ "en-dash" : "\u2013" }' | USE_XP=. xp -w '
  uses("webservices.rest.RestJsonDeserializer");
  (new RestJsonDeserializer())->deserialize(Console::$in->getStream());
'
Exception webservices.json.JsonException (Cannot decode string ... to iso-8859-1)
  at webservices.json.JsonDecoder::parse(text.StreamTokenizer{}, (0xa)'iso-8859-1') [line 330 ...
  at <main>::iconv() [line 392 of JsonParser.class.php] iconv(): Detected an illegal character...
  at webservices.json.JsonParser::yyparse(webservices.json.JsonLexer{}) [line 120 ...
```

## When passing utf-8 encoding:
```sh
$ echo '{ "en-dash" : "\u2013" }' | USE_XP=. xp -w '
  uses("webservices.rest.RestJsonDeserializer");
  (new RestJsonDeserializer())->deserialize(Console::$in->getStream(), "utf-8");
'
[
  en-dash => "–"
]
```