### PR TITLE
Move static initializer from Throwable -> XPClass

### DIFF
--- a/core/src/main/php/lang/Throwable.class.php
+++ b/core/src/main/php/lang/Throwable.class.php
@@ -25,25 +25,6 @@
       $cause    = NULL,
       $message  = '',
       $trace    = array();
-    
-    static function __static() {
-    
-      // Workaround for missing detail information about return types in
-      // builtin classes.
-      xp::$meta['php.Exception']= array(
-        'class' => array(4 => NULL, array()),
-        0 => array(),
-        1 => array(
-          'getMessage'       => array(1 => array(), 'string', array(), NULL, array()),
-          'getCode'          => array(1 => array(), 'int', array(), NULL, array()),
-          'getFile'          => array(1 => array(), 'string', array(), NULL, array()),
-          'getLine'          => array(1 => array(), 'int', array(), NULL, array()),
-          'getTrace'         => array(1 => array(), 'var[]', array(), NULL, array()),
-          'getPrevious'      => array(1 => array(), 'lang.Throwable', array(), NULL, array()),
-          'getTraceAsString' => array(1 => array(), 'string', array(), NULL, array()),
-        )
-      );
-    }
 
     /**
      * Constructor

--- a/core/src/main/php/lang/XPClass.class.php
+++ b/core/src/main/php/lang/XPClass.class.php
@@ -64,7 +64,26 @@
   class XPClass extends Type {
     protected $_class= NULL;
     public $_reflect= NULL;
+
+    static function __static() {
     
+      // Workaround for missing detail information about return types in
+      // builtin classes.
+      xp::$meta['php.Exception']= array(
+        'class' => array(4 => NULL, array()),
+        0 => array(),
+        1 => array(
+          'getMessage'       => array(1 => array(), 'string', array(), NULL, array()),
+          'getCode'          => array(1 => array(), 'int', array(), NULL, array()),
+          'getFile'          => array(1 => array(), 'string', array(), NULL, array()),
+          'getLine'          => array(1 => array(), 'int', array(), NULL, array()),
+          'getTrace'         => array(1 => array(), 'var[]', array(), NULL, array()),
+          'getPrevious'      => array(1 => array(), 'lang.Throwable', array(), NULL, array()),
+          'getTraceAsString' => array(1 => array(), 'string', array(), NULL, array()),
+        )
+      );
+    }
+
     /**
      * Constructor
      *


### PR DESCRIPTION
This way, we don't execute it for every subclass of Throwable, which there are quite a bit of.