### PR TITLE
Fix namespaces with uses

### DIFF
--- a/core/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace net\xp_framework\unittest\core;
 
+use lang\ClassLoader;
+
 /**
  * Tests the XP Framework's optional namespace support
- *
  */
 class NamespaceAliasTest extends \unittest\TestCase {
 
@@ -23,7 +24,7 @@ class NamespaceAliasTest extends \unittest\TestCase {
 
   #[@test]
   public function defined_class_exists() {
-    \lang\ClassLoader::defineClass(
+    ClassLoader::defineClass(
       'net.xp_framework.unittest.core.NamespaceAliasClassFixture', 
       'lang.Object', 
       array(), 
@@ -34,7 +35,7 @@ class NamespaceAliasTest extends \unittest\TestCase {
 
   #[@test]
   public function defined_interface_exists() {
-    \lang\ClassLoader::defineInterface(
+    ClassLoader::defineInterface(
       'net.xp_framework.unittest.core.NamespaceAliasInterfaceFixture', 
       array(), 
       '{}'
@@ -44,19 +45,25 @@ class NamespaceAliasTest extends \unittest\TestCase {
 
   #[@test]
   public function autoloaded_class_exists() {
-    new \net\xp_framework\unittest\core\NamespaceAliasAutoloadedFixture();    // Triggers autoloader
+    new NamespaceAliasAutoloadedFixture();              // Triggers autoloader
     $this->assertTrue(class_exists('net\xp_framework\unittest\core\NamespaceAliasAutoloadedFixture', false));
   }
 
   #[@test]
   public function autoloaded_namespaced_class_exists() {
-    new \net\xp_framework\unittest\core\NamespaceAliasAutoloadedNamespacedFixture();    // Triggers autoloader
+    new NamespaceAliasAutoloadedNamespacedFixture();    // Triggers autoloader
     $this->assertTrue(class_exists('net\xp_framework\unittest\core\NamespaceAliasAutoloadedNamespacedFixture', false));
   }
 
   #[@test]
   public function autoloaded_fq_class_exists() {
-    new \net\xp_framework\unittest\core\NamespaceAliasAutoloadedFQFixture();    // Triggers autoloader
+    new NamespaceAliasAutoloadedFQFixture();            // Triggers autoloader
     $this->assertTrue(class_exists('net\xp_framework\unittest\core\NamespaceAliasAutoloadedFQFixture', false));
+  }
+
+  #[@test]
+  public function namespaced_classes_aliased_to_short_name_when_loaded_via_uses() {
+    uses('net.xp_framework.unittest.core.NamespaceAliasAutoloadedNamespacedFixture');
+    $this->assertTrue(class_exists('NamespaceAliasAutoloadedNamespacedFixture', false));
   }
 }

--- a/core/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/core/NamespaceAliasTest.class.php
@@ -66,4 +66,11 @@ class NamespaceAliasTest extends \unittest\TestCase {
     uses('net.xp_framework.unittest.core.NamespaceAliasAutoloadedNamespacedFixture');
     $this->assertTrue(class_exists('NamespaceAliasAutoloadedNamespacedFixture', false));
   }
+
+  #[@test]
+  public function namespaced_classes_not_aliased_twice_when_loaded_via_uses() {
+    uses('net.xp_framework.unittest.core.NamespaceAliasAutoloadedNamespacedFixture');
+    uses('net.xp_framework.unittest.core.NamespaceAliasAutoloadedNamespacedFixture');
+    $this->assertTrue(class_exists('NamespaceAliasAutoloadedNamespacedFixture', false));
+  }
 }

--- a/core/tools/lang.base.php
+++ b/core/tools/lang.base.php
@@ -488,11 +488,16 @@
   // }}}
 
   // {{{ proto void uses (string* args)
-  //     Uses one or more classes
+  //     Uses one or more classes and ensures namespaced classes are aliased
+  //     to their non-namespaced short name
   function uses() {
     $scope= NULL;
     foreach (func_get_args() as $str) {
       $class= xp::$loader->loadClass0($str);
+
+      if (strstr($class, '\\')) {
+        class_alias($class, substr($class, strrpos($class, '\\')+ 1), false);
+      }
 
       // Tricky: We can arrive at this point without the class actually existing:
       // A : uses("B")

--- a/core/tools/lang.base.php
+++ b/core/tools/lang.base.php
@@ -495,8 +495,11 @@
     foreach (func_get_args() as $str) {
       $class= xp::$loader->loadClass0($str);
 
-      if (strstr($class, '\\')) {
-        class_alias($class, substr($class, strrpos($class, '\\')+ 1), false);
+      if ($p= strrpos($class, '\\')) {
+        $short= substr($class, $p+ 1);
+        if (!class_exists($short, false) && !interface_exists($short, false)) {
+          class_alias($class, $short, false);
+        }
       }
 
       // Tricky: We can arrive at this point without the class actually existing:


### PR DESCRIPTION
This pull request backports [functionality already in XP6](https://github.com/xp-framework/core/commit/1fd98a91f6a3cc585f5db3dde8e2cf31dcfb0fe3) which extremely eases the migration to namespaces by aliasing namespaced classes to short names when using `uses()`. 