### PR TITLE
preventing fatal error in Url::parseQuery

### DIFF
--- a/core/src/main/php/peer/URL.class.php
+++ b/core/src/main/php/peer/URL.class.php
@@ -230,7 +230,9 @@
         }
         if ($start= strpos($key, '[')) {    // Array notation
           $base= substr($key, 0, $start);
-          isset($params[$base]) || $params[$base]= array();
+          if (!isset($params[$base]) || !is_array($params[$base])) {
+            $params[$base]= array();
+          }
           $ptr= &$params[$base];
           $offset= 0;
           do {

--- a/core/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/URLTest.class.php
@@ -1441,4 +1441,16 @@ class URLTest extends TestCase {
     $u= new URL('http://user:pass@localhost/path?query#fragment');
     $this->assertEquals('http://user:********@localhost/path?query#fragment', $u->toString());
   }
+  
+  /**
+   * Verifies URLs with hashed arrays do not fail to parse
+  *
+  * URL::parseQuery Fatal Error'd when a param is defined as a scalar value an then overwriten by treating it as an array
+   *
+   */
+  #[@test]
+  public function arrayParamOverwritesParamWithoutFatalError() {
+    $u= new URL('http://unittest.localhost/includes/orderSuccess.inc.php?&glob=1&cart_order_id=1&glob[rootDir]=http://cirt.net/rfiinc.txt?');
+    $this->assertEquals(array('rootDir' => 'http://cirt.net/rfiinc.txt?'), $u->getParam('glob'));
+  }
 }


### PR DESCRIPTION
This URL resulted in a fatal error and seems not to be fixed already:

http://unittest.localhost/includes/orderSuccess.inc.php?&glob=1&cart_order_id=1&glob[rootDir]=http://cirt.net/rfiinc.txt?"

hth