### PR TITLE
Httprequest patch arraykey

### DIFF
--- a/core/src/main/php/peer/http/HttpRequest.class.php
+++ b/core/src/main/php/peer/http/HttpRequest.class.php
@@ -167,10 +167,10 @@
         foreach ($this->parameters as $name => $value) {
           if (is_array($value)) {
             foreach ($value as $k => $v) {
-              $query.= '&'.$name.'['.$k.']='.urlencode($v);
+              $query.= '&'.urlencode($name).'['.urlencode($k).']='.urlencode($v);
             }
           } else {
-            $query.= '&'.$name.'='.urlencode($value);
+            $query.= '&'.urlencode($name).'='.urlencode($value);
           }
         }
       }

--- a/core/src/test/php/net/xp_framework/unittest/peer/http/HttpRequestTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/http/HttpRequestTest.class.php
@@ -446,4 +446,48 @@ class HttpRequestTest extends TestCase {
       $r->getHeaderString()
     );
   }
+  
+ /**
+  * Test HTTP GET - parameters via setParameters(array<string, string>)
+  * BUT array key contains spaces!
+  *
+  * Example of assoc-array:
+  *  $test= array(
+  *      '10 EUR' => '100 teststeine',
+  *      '7.14 TRY' => '200 teststeine'
+  *  );
+  */
+  #[@test]
+  public function get_url_with_array_params_spaced_key() {
+    $r= new HttpRequest(new URL('http://example.com/'));
+    $r->setMethod(HttpConstants::GET);
+    $r->setParameters(array('10 EUR' => 'test 123'));
+    $this->assertEquals(
+      "GET /?10+EUR=test+123 HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
+      $r->getRequestString()
+    );
+  }
+
+  /**
+   * Test HTTP GET - parameters via setParameters(array<array<string, string>>)
+   * BUT array contains array which might have keys containing spaces!
+   *
+   * Example of assoc-array:
+   *  $test= array(
+   *      'test' => array(
+   *          '10 EUR' => '100 teststeine',
+   *          '7.14 TRY' => '200 teststeine'
+   *      )
+   *  );
+   */
+   #[@test]
+   public function get_url_with_assoc_array_containing_assoc_array() {
+    $r= new HttpRequest(new URL('http://example.com/'));
+    $r->setMethod(HttpConstants::GET);
+    $r->setParameters(array('test' => array('10 EUR' => 'test 123')));
+    $this->assertEquals(
+      "GET /?test[10+EUR]=test+123 HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
+      $r->getRequestString()
+    );
+  }
 }

--- a/core/src/test/php/net/xp_framework/unittest/peer/http/HttpRequestTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/http/HttpRequestTest.class.php
@@ -490,4 +490,48 @@ class HttpRequestTest extends TestCase {
       $r->getRequestString()
     );
   }
+
+  /**
+   * Test HTTP GET - parameters via setParameters(array<string, string>)
+   * BUT array key contains spaces!
+   *
+   * Example of assoc-array:
+   *  $test= array(
+   *      '10 EUR' => '100 teststeine',
+   *      '7.14 TRY' => '200 teststeine'
+   *  );
+   */
+   #[@test]
+   public function get_url_with_array_params_spaced_key() {
+     $r= new HttpRequest(new URL('http://example.com/'));
+     $r->setMethod(HttpConstants::GET);
+     $r->setParameters(array('10 EUR' => 'test 123'));
+     $this->assertEquals(
+       "GET /?10+EUR=test+123 HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
+       $r->getRequestString()
+     );
+   }
+
+   /**
+    * Test HTTP GET - parameters via setParameters(array<array<string, string>>)
+    * BUT array contains array which might have keys containing spaces!
+    *
+    * Example of assoc-array:
+    *  $test= array(
+    *      'test' => array(
+    *          '10 EUR' => '100 teststeine',
+    *          '7.14 TRY' => '200 teststeine'
+    *      )
+    *  );
+    */
+   #[@test]
+   public function get_url_with_assoc_array_containing_assoc_array() {
+     $r= new HttpRequest(new URL('http://example.com/'));
+     $r->setMethod(HttpConstants::GET);
+     $r->setParameters(array('test' => array('10 EUR' => 'test 123')));
+     $this->assertEquals(
+       "GET /?test[10+EUR]=test+123 HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
+        $r->getRequestString()
+     );
+   }
 }

--- a/core/src/test/php/net/xp_framework/unittest/peer/http/HttpRequestTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/http/HttpRequestTest.class.php
@@ -490,48 +490,4 @@ class HttpRequestTest extends TestCase {
       $r->getRequestString()
     );
   }
-
-  /**
-   * Test HTTP GET - parameters via setParameters(array<string, string>)
-   * BUT array key contains spaces!
-   *
-   * Example of assoc-array:
-   *  $test= array(
-   *      '10 EUR' => '100 teststeine',
-   *      '7.14 TRY' => '200 teststeine'
-   *  );
-   */
-   #[@test]
-   public function get_url_with_array_params_spaced_key() {
-     $r= new HttpRequest(new URL('http://example.com/'));
-     $r->setMethod(HttpConstants::GET);
-     $r->setParameters(array('10 EUR' => 'test 123'));
-     $this->assertEquals(
-       "GET /?10+EUR=test+123 HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
-       $r->getRequestString()
-     );
-   }
-
-   /**
-    * Test HTTP GET - parameters via setParameters(array<array<string, string>>)
-    * BUT array contains array which might have keys containing spaces!
-    *
-    * Example of assoc-array:
-    *  $test= array(
-    *      'test' => array(
-    *          '10 EUR' => '100 teststeine',
-    *          '7.14 TRY' => '200 teststeine'
-    *      )
-    *  );
-    */
-   #[@test]
-   public function get_url_with_assoc_array_containing_assoc_array() {
-     $r= new HttpRequest(new URL('http://example.com/'));
-     $r->setMethod(HttpConstants::GET);
-     $r->setParameters(array('test' => array('10 EUR' => 'test 123')));
-     $this->assertEquals(
-       "GET /?test[10+EUR]=test+123 HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
-        $r->getRequestString()
-     );
-   }
 }


### PR DESCRIPTION
HttpRequest::getPayload() failed when array key contained spaces.