### PR TITLE
Fix problem with listing empty directories

### DIFF
--- a/core/src/main/php/peer/ftp/FtpDir.class.php
+++ b/core/src/main/php/peer/ftp/FtpDir.class.php
@@ -41,7 +41,7 @@
      * @throws  io.IOException in case of an I/O error
      */
     public function entries() {
-      if (NULL === ($list= $this->connection->listingOf($this->name))) {
+      if (NULL === ($list= $this->connection->listingOf($this->name, '-al'))) {
         throw new IOException('Cannot list "'.$this->name.'"');
       }
       

--- a/core/src/test/php/net/xp_framework/unittest/peer/ftp/IntegrationTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/ftp/IntegrationTest.class.php
@@ -23,6 +23,7 @@ class IntegrationTest extends TestCase {
    * Callback for when server is connected
    *
    * @param  string $bindAddress
+   * @return void
    */
   public static function connected($bindAddress) {
     self::$bindAddress= $bindAddress;
@@ -30,6 +31,8 @@ class IntegrationTest extends TestCase {
 
   /**
    * Callback for when server should be shut down
+   *
+   * @return void
    */
   public static function shutdown() {
     $c= new FtpConnection('ftp://test:test@'.self::$bindAddress);
@@ -38,9 +41,7 @@ class IntegrationTest extends TestCase {
     $c->close();
   }
 
-  /**
-   * Sets up test case
-   */
+  /** @return void */
   public function setUp() {
     $this->conn= new FtpConnection('ftp://test:test@'.self::$bindAddress.'?passive=1&timeout=1');
   }
@@ -82,10 +83,6 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function sendCwd() {
     $this->conn->connect();
@@ -93,10 +90,6 @@ class IntegrationTest extends TestCase {
     $this->assertEquals('250 "/htdocs" is new working directory', $r[0]);
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function listingWithoutParams() {
     $this->conn->connect();
@@ -106,10 +99,6 @@ class IntegrationTest extends TestCase {
     $this->assertEquals(true, (bool)strpos($list, 'index.html'), $list);
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function cwdBackToRoot() {
     $this->sendCwd();
@@ -117,10 +106,6 @@ class IntegrationTest extends TestCase {
     $this->assertEquals('250 "/" is new working directory', $r[0]);
   }
 
-  /**
-   * Test
-   *
-   */
   #[@test]
   public function cwdRelative() {
     $this->conn->connect();
@@ -134,11 +119,6 @@ class IntegrationTest extends TestCase {
     $this->assertEquals('250 "/outer/inner" is new working directory', $r[0]);
   }
 
-  /**
-   * Test retrieving the ".trash" directory which is empty.(except for
-   * the ".svn" directory, if test runs within svn checkout).
-   *
-   */
   #[@test]
   public function dotTrashDir() {
     $this->conn->connect();
@@ -153,10 +133,6 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test retrieving the "htdocs" directory which is not empty.
-   *
-   */
   #[@test]
   public function htdocsDir() {
     $this->conn->connect();
@@ -169,30 +145,18 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test checking for a non-existant directory
-   *
-   */
   #[@test]
   public function nonExistantDir() {
     $this->conn->connect();
     $this->assertFalse($this->conn->rootDir()->hasDir(':DOES_NOT_EXIST'));
   }
 
-  /**
-   * Test retrieving a non-existant directory raises an exception.
-   *
-   */
   #[@test, @expect('io.FileNotFoundException')]
   public function getNonExistantDir() {
     $this->conn->connect();
     $this->conn->rootDir()->getDir(':DOES_NOT_EXIST');
   }
 
-  /**
-   * Test retrieving the "htdocs/index.html" file
-   *
-   */
   #[@test]
   public function indexHtml() {
     $this->conn->connect();
@@ -204,10 +168,6 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test retrieving the "htdocs/index.html" file
-   *
-   */
   #[@test]
   public function whitespacesHtml() {
     $this->conn->connect();
@@ -219,50 +179,30 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test checking for a non-existant file
-   *
-   */
   #[@test]
   public function nonExistantFile() {
     $this->conn->connect();
     $this->assertFalse($this->conn->rootDir()->getDir('htdocs')->hasFile(':DOES_NOT_EXIST'));
   }
 
-  /**
-   * Test retrieving a non-existant file raises an exception
-   *
-   */
   #[@test, @expect('io.FileNotFoundException')]
   public function getNonExistantFile() {
     $this->conn->connect();
     $this->conn->rootDir()->getDir('htdocs')->getFile(':DOES_NOT_EXIST');
   }
 
-  /**
-   * Test retrieving a directory with getFile() raises an exception
-   *
-   */
   #[@test, @expect('lang.IllegalStateException')]
   public function directoryViaGetFile() {
     $this->conn->connect();
     $this->conn->rootDir()->getFile('htdocs');
   }
 
-  /**
-   * Test retrieving a file with getDir() raises an exception
-   *
-   */
   #[@test, @expect('lang.IllegalStateException')]
   public function fileViaGetDir() {
     $this->conn->connect();
     $this->conn->rootDir()->getDir('htdocs')->getDir('index.html');
   }
 
-  /**
-   * Test uploading
-   *
-   */
   #[@test]
   public function uploadFile() {
     $this->conn->connect();
@@ -285,10 +225,6 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test renaming a file
-   *
-   */
   #[@test]
   public function renameFile() {
     $this->conn->connect();
@@ -314,10 +250,6 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test moving a file
-   *
-   */
   #[@test]
   public function moveFile() {
     $this->conn->connect();
@@ -345,10 +277,6 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test downloading
-   *
-   */
   #[@test]
   public function downloadFile() {
     $this->conn->connect();
@@ -363,10 +291,6 @@ class IntegrationTest extends TestCase {
     $this->assertEquals("<html/>\n", $m->getBytes());
   }
 
-  /**
-   * Test FtpFile::getInputStream()
-   *
-   */
   #[@test]
   public function getInputStream() {
     $this->conn->connect();
@@ -381,10 +305,6 @@ class IntegrationTest extends TestCase {
     $this->assertEquals("<html/>\n", Streams::readAll($s));
   }
 
-  /**
-   * Test FtpFile::getInputStream()
-   *
-   */
   #[@test]
   public function getInputStreams() {
     $this->conn->connect();
@@ -400,10 +320,6 @@ class IntegrationTest extends TestCase {
     }
   }
 
-  /**
-   * Test FtpFile::getOutputStream()
-   *
-   */
   #[@test]
   public function getOutputStream() {
     $this->conn->connect();

--- a/core/src/test/php/net/xp_framework/unittest/peer/ftp/IntegrationTest.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/ftp/IntegrationTest.class.php
@@ -146,6 +146,16 @@ class IntegrationTest extends TestCase {
   }
 
   #[@test]
+  public function emptyDir() {
+    $this->conn->connect();
+    with ($r= $this->conn->rootDir()); {
+      $dir= $r->newDir('.new');
+      $this->assertClass($dir, 'peer.ftp.FtpDir');
+      $this->assertEquals(0, $dir->entries()->size());
+    }
+  }
+
+  #[@test]
   public function nonExistantDir() {
     $this->conn->connect();
     $this->assertFalse($this->conn->rootDir()->hasDir(':DOES_NOT_EXIST'));

--- a/core/src/test/php/net/xp_framework/unittest/peer/ftp/TestingStorage.class.php
+++ b/core/src/test/php/net/xp_framework/unittest/peer/ftp/TestingStorage.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\xp_framework\unittest\peer\ftp;
 
 use peer\ftp\server\storage\Storage;
-
+use peer\ftp\server\storage\StorageEntry;
 
 /**
  * Memory storage used
@@ -28,7 +28,7 @@ class TestingStorage extends \lang\Object implements Storage {
    *
    * @param   peer.ftp.server.storage.StorageEntry $e
    */
-  public function add(\peer\ftp\server\storage\StorageEntry $e) {
+  public function add(StorageEntry $e) {
     $this->entries[$e->getFileName()]= $e;
   }
 


### PR DESCRIPTION
This pull request fixes a bug with listing empty directories. The server we where using always returned `.` and `..` regardless of the `LIST` options, while ProFTPd only does so when supplying `-al` (see http://www.proftpd.org/docs/howto/ListOptions.html).

```php
uses(
  'peer.ftp.FtpConnection',
  'util.log.LogCategory',
  'util.log.ConsoleAppender',
  'util.cmd.Console'
);

$c= new FtpConnection('ftp://user:pass@example.com:6200');
$c->connect();
$c->setTrace((new LogCategory('protocol'))->withAppender(new ConsoleAppender()));

Console::writeLine($c->rootDir()->getDir('/offerings/prod/auto/')->entries());
```

This should return an empty array but instead produced the following output:

```
Uncaught exception: Exception lang.reflect.TargetInvocationException (xp´runtime´Dump::main)
  at lang.reflect.Method::invoke(NULL, array[1]) [line 58 of class.php]
Caused by Exception io.IOException (Cannot list "/offerings/prod/auto/")
  at peer.ftp.FtpDir::entries() [line 1 of Dump.class.php(51) : eval()'d code]
  at <main>::eval() [line 51 of Dump.class.php]
  at xp.runtime.Dump::main(array[2]) [line 0 of StackTraceElement.class.php]
  at php.ReflectionMethod::invokeArgs(NULL, array[1]) [line 95 of Method.class.php]
```

After the fix, the output is:

```
peer.ftp.FtpEntryList(0 entries)@[
  0 => "drwxr-xr-x   2 offerings www-data        6 Apr 20 07:05 ."
  1 => "drwxr-xr-x   9 offerings www-data       90 Sep 17  2015 .."
]
```